### PR TITLE
MYSTRAN 15.1

### DIFF
--- a/Source/EMG/EMG2/ELMOFF.f90
+++ b/Source/EMG/EMG2/ELMOFF.f90
@@ -279,7 +279,7 @@
          
          DO J=1,6*ELGP
             DO K=1,6*ELGP
-               KE(J,K) = KE1(J,K)!+Ksita
+               KE(J,K) = KE1(J,K)+Ksita
             ENDDO
          ENDDO
 

--- a/Source/Modules/MYSTRAN_Version.f90
+++ b/Source/Modules/MYSTRAN_Version.f90
@@ -35,7 +35,7 @@
       SAVE
 
       CHARACTER(256*BYTE)            :: MYSTRAN_COMMENT  = '*** Please report any problems to mystransolver@gmail.com ***'
-      CHARACTER(  8*BYTE), PARAMETER :: MYSTRAN_VER_NUM  = '15.0'
+      CHARACTER(  8*BYTE), PARAMETER :: MYSTRAN_VER_NUM  = '15.1'
       CHARACTER(  3*BYTE), PARAMETER :: MYSTRAN_VER_MONTH= 'Dec'
       CHARACTER(  2*BYTE), PARAMETER :: MYSTRAN_VER_DAY  = '19'
       CHARACTER(  4*BYTE), PARAMETER :: MYSTRAN_VER_YEAR = '2023'


### PR DESCRIPTION
This is a minor update, but important nonetheless!

Basically, I added a shell drilling stiffness parameter, `K6ROT`, present in many Nastran-like solvers. The default value is `100.0`. It only affects QUAD4 and TRIA3 shells.

The commit is small because most of the "groundwork" to add `K6ROT` was done in some commits in GH-9. This update merely re-enables the feature. 

This was done in order to have a "clean" 15.0 release, containing just the bug fixes and no `K6ROT`.

Of course, this new feature will require some updates to the manual. As stated in GH-9, that's in the works.

Feedback is more than welcome!