### PR TITLE
MYSTRAN Update 15.1.4

### DIFF
--- a/Source/LK9/L91/WRITE_ELEM_ENGR_FORCE.f90
+++ b/Source/LK9/L91/WRITE_ELEM_ENGR_FORCE.f90
@@ -263,6 +263,8 @@ headr:IF (IHDR == 'Y') THEN
 
       ! Write element force output
       IF      (TYPE == 'BAR     ') THEN
+         
+         CALL GET_MAX_MIN_ABS ( 1, 8 )
 
          ! (1) PRINT, (2) PLOT, (3) PUNCH, (4) NEU, (5) CSV
          IF (WRITE_OP2)  THEN  ! op2/plot
@@ -279,7 +281,7 @@ headr:IF (IHDR == 'Y') THEN
            DO I=1,NUM
               WRITE(F06,1102) FILL(1: 0), EID_OUT_ARRAY(I,1),(OGEL(I,J),J=1,8)
            ENDDO   
-           CALL GET_MAX_MIN_ABS ( 1, 8 )
+           !CALL GET_MAX_MIN_ABS ( 1, 8 )
            WRITE(F06,1103) FILL(1: 0), FILL(1: 0), (MAX_ANS(J),J=1,8), FILL(1: 0), (MIN_ANS(J),J=1,8), FILL(1: 0),                 &
                                                    (ABS_ANS(J),J=1,8), FILL(1: 0)
          ENDIF

--- a/Source/Modules/MYSTRAN_Version.f90
+++ b/Source/Modules/MYSTRAN_Version.f90
@@ -35,7 +35,7 @@
       SAVE
 
       CHARACTER(256*BYTE)            :: MYSTRAN_COMMENT  = '*** Please report any problems to mystransolver@gmail.com ***'
-      CHARACTER(  8*BYTE), PARAMETER :: MYSTRAN_VER_NUM  = '15.1.3'
+      CHARACTER(  8*BYTE), PARAMETER :: MYSTRAN_VER_NUM  = '15.1.4'
       CHARACTER(  3*BYTE), PARAMETER :: MYSTRAN_VER_MONTH= 'Dec'
       CHARACTER(  2*BYTE), PARAMETER :: MYSTRAN_VER_DAY  = '20'
       CHARACTER(  4*BYTE), PARAMETER :: MYSTRAN_VER_YEAR = '2023'


### PR DESCRIPTION
This update fixes a small memory bug. Basically, when writing element engineering forces for BAR elements, the min/max/abs values were only being computed if F06 output was requested. So, if writing only the .ANS, uninitialized (garbage) values would be written. I moved the call that computes said values to the top of the BAR case, thus fixing the bug (I think). 