### PR TITLE
MYSTRAN Update 15.1.7

### DIFF
--- a/Source/LK2/REDUCE_N_FS.f90
+++ b/Source/LK2/REDUCE_N_FS.f90
@@ -88,6 +88,11 @@
       REAL(DOUBLE)                    :: KFF_DIAG(NDOFF)       ! Diagonal terms from KFF
       REAL(DOUBLE)                    :: KFF_MAX_DIAG          ! Max diag term from KFF
 
+
+      ! ensure output units are set
+      OUNT(1) = ERR
+      OUNT(2) = F06
+
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN
          CALL OURTIM

--- a/Source/LK5/LINK5.f90
+++ b/Source/LK5/LINK5.f90
@@ -271,7 +271,12 @@
                CALL OUTA_HERE ( 'Y' )
             ENDIF
 
-            CALL FILE_CLOSE ( L1H, LINK1H, L1HSTAT, 'Y' )
+            IF ((SOL_NAME(1:8) == 'BUCKLING') .AND. (LOAD_ISTEP == 1)) THEN
+               ! ensure L1H survives for the second round
+               CALL FILE_CLOSE ( L1H, LINK1H, 'KEEP', 'Y' )
+            ELSE
+               CALL FILE_CLOSE ( L1H, LINK1H, L1HSTAT, 'Y' )
+            END IF
 
          ENDIF
 

--- a/Source/Modules/MYSTRAN_Version.f90
+++ b/Source/Modules/MYSTRAN_Version.f90
@@ -35,9 +35,9 @@
       SAVE
 
       CHARACTER(256*BYTE)            :: MYSTRAN_COMMENT  = '*** Please report any problems to mystransolver@gmail.com ***'
-      CHARACTER(  8*BYTE), PARAMETER :: MYSTRAN_VER_NUM  = '15.1.6'
+      CHARACTER(  8*BYTE), PARAMETER :: MYSTRAN_VER_NUM  = '15.1.7'
       CHARACTER(  3*BYTE), PARAMETER :: MYSTRAN_VER_MONTH= 'Mar'
-      CHARACTER(  2*BYTE), PARAMETER :: MYSTRAN_VER_DAY  = '14'
+      CHARACTER(  2*BYTE), PARAMETER :: MYSTRAN_VER_DAY  = '24'
       CHARACTER(  4*BYTE), PARAMETER :: MYSTRAN_VER_YEAR = '2024'
       CHARACTER( 33*BYTE), PARAMETER :: MYSTRAN_AUTHOR   = 'MYSTRAN developed by Dr Bill Case'
 


### PR DESCRIPTION
This update fixes a double-whammy kind of bug. Basically, the L1H temp file (contains enforced displacement data) didn't survive into the second step of a buckling problem. That should cause a fatal error to be issued, but guess what? The subroutine attempting the open doesn't set `OUNT`, the variable containing the unit numbers for message output files (ERR and F06), so it'd contain uninitialised integers. The result? 50% chance it was negative, causing a runtime error. It being positive caused a memory error and a likely crash.

Check the commit-level data for details.