### PR TITLE
fixed segfault caused by closed ANS file

### DIFF
--- a/Source/LK9/L92/GP_FORCE_BALANCE_PROC.f90
+++ b/Source/LK9/L92/GP_FORCE_BALANCE_PROC.f90
@@ -812,10 +812,9 @@ i_do1:   DO I=1,NGRID                                      ! (2) Set initial val
           IF (IERR /= 0) THEN
               WRITE(ERR,*) 'GPFORCE_FXYZ_MXYZ DEALLOCATE error'
           ENDIF
+          FLUSH(OP2)
       ENDIF
-      FLUSH(OP2)
       FLUSH(F06)
-      FLUSH(ANS)
       FLUSH(ERR)
 
 ! **********************************************************************************************************************************


### PR DESCRIPTION
GPFORCE has a flush to the ANS file, so if ANS is closed, the code will fatal.

We should also add some all_element tests that don't use the ANS file. 

fixes #65 