### PR TITLE
Cards may now have comments in them

### DIFF
--- a/Build_Test_Cases/statics/bar_tube_dollar.bdf
+++ b/Build_Test_Cases/statics/bar_tube_dollar.bdf
@@ -1,0 +1,41 @@
+ID BAR,NONZERO I12
+SOL 1
+CEND
+TITLE = 1 BAR WITH END LOADS AND WITH NONZERO I12
+LOAD  = 1
+DISP          = ALL
+ECHO          = UNSORT
+ELFORCE(BOTH) = ALL
+GPFORCE       = ALL
+MPCFORCE      = ALL
+OLOAD         = ALL
+SPCFORCE      = ALL
+STRESS        = ALL
+ELDATA(4,PRINT) = ALL
+ELDATA(5,PRINT) = ALL
+BEGIN BULK
+$
+GRID    101             0.      0.      0.              123456
+GRID    201             10.     0.      0.              14
+$
+CBAR    11      10      101     201     0.      1.      0.
+$
+$      pid, mid, group, type
+PBARL, 10, 20, , TUBE
+$cat
+,1.0,0.9,0.0
+$
+MAT1    20      1.E+7   4.+6            .1      1.
+$
+LOAD    1        1.0     2.0     11      3.0     12
+FORCE   11       201             1.      0.      3.     -6. 
+MOMENT  12       201             1.      0.      2.      3.  
+$
+PARAM   SOLLIB   IntMKL
+PARAM   GRDPNT   0
+PARAM   POST     -1
+$
+DEBUG   192     2                                                       GPFO summary
+DEBUG   200     1                                                       ANS
+$
+ENDDATA

--- a/Source/LK1/L1U/NEXTC.f90
+++ b/Source/LK1/L1U/NEXTC.f90
@@ -89,6 +89,22 @@
          CALL READERR ( IOCHK, INFILE, MESSAG, REC_NO, OUNT, 'Y' )
          FATAL_ERR = FATAL_ERR + 1
       ENDIF
+      
+      ! we (maybe) found a comment line inside the card
+      ! loop until we find a non-comment line using the same
+      ! block as above
+      !
+      ! NOTE: comment lines must start with a $, so a space is
+      !       not considered a comment
+      DO WHILE (TCARD(1:1) == '$') 
+         READ(IN1,101,IOSTAT=IOCHK) TCARD  ! Read next card
+         CARD_IN = TCARD
+         IF (IOCHK /= 0) THEN
+            REC_NO = -99
+            CALL READERR ( IOCHK, INFILE, MESSAG, REC_NO, OUNT, 'Y' )
+            FATAL_ERR = FATAL_ERR + 1
+         ENDIF
+      ENDDO
 
 ! Remove any comments within the CARD by deleting everything from $ on (after col 1)
 


### PR DESCRIPTION
Embedded card comments (see an example in 67 or the pull request test case) must start with a dollar sign.  Note that a single blank character is **not** treated as a comment line.  This fixes the PBARL fatal error that for a card line a PCOMP could result in missing layers.

fixes #67 
