### PR TITLE
added common READ_BDF_LINE subroutine

### DIFF
--- a/Build_Test_Cases/statics/bar_tube_dollar.bdf
+++ b/Build_Test_Cases/statics/bar_tube_dollar.bdf
@@ -3,23 +3,24 @@ SOL 1
 CEND
 TITLE = 1 BAR WITH END LOADS AND WITH NONZERO I12
 LOAD  = 1
-DISP          = ALL
+DISP(plot)    = ALL
 ECHO          = UNSORT
-ELFORCE(BOTH) = ALL
-GPFORCE       = ALL
+ELFORCE(plot) = ALL
+GPFORCE(plot) = ALL
 MPCFORCE      = ALL
-OLOAD         = ALL
-SPCFORCE      = ALL
-STRESS        = ALL
+OLOAD(plot)   = ALL
+SPCFORCE(plot)  = ALL
+STRESS(plot)    = ALL
 ELDATA(4,PRINT) = ALL
 ELDATA(5,PRINT) = ALL
 BEGIN BULK
 $
-GRID    101             0.      0.      0.              123456
-GRID    201             10.     0.      0.              14
+grid    101             0.      0.      0.              123456
+$
+grid    201             10.     0.      0.              14
 $
 CBAR    11      10      101     201     0.      1.      0.
-$
+
 $      pid, mid, group, type
 PBARL, 10, 20, , TUBE
 $cat
@@ -29,6 +30,7 @@ MAT1    20      1.E+7   4.+6            .1      1.
 $
 LOAD    1        1.0     2.0     11      3.0     12
 FORCE   11       201             1.      0.      3.     -6. 
+
 MOMENT  12       201             1.      0.      2.      3.  
 $
 PARAM   SOLLIB   IntMKL

--- a/Source/LK1/L1A-CC/CC_SET.f90
+++ b/Source/LK1/L1A-CC/CC_SET.f90
@@ -133,9 +133,8 @@
             READ(TOKEN(1),'(I8)') SETID
          ENDIF
       ENDIF
-  
-! Update NSETS and check that other sets with same ID not already defined
- 
+
+      ! Update NSETS and check that other sets with same ID not already defined
       NSETS = NSETS + 1
       IF (NSETS > LSETS) THEN
          FATAL_ERR = FATAL_ERR + 1
@@ -220,11 +219,10 @@ i_do_4:  DO I=CC_ENTRY_LEN,1,-1
                EXIT i_do_4
             ENDIF
          ENDDO i_do_4
- 
-! If there is a continuation card, read it
- 
+
+         ! If there is a continuation card, read it
          IF (ICONT == 1) THEN
-            READ(IN1,101,IOSTAT=IOCHK1) CARD1
+            CALL READ_BDF_LINE(IN1, IOCHK1, CARD1)
             WRITE(F06,'(A)') CARD1
             IF (IOCHK1 > 0) THEN
                FATAL_ERR = FATAL_ERR + 1
@@ -236,11 +234,13 @@ i_do_4:  DO I=CC_ENTRY_LEN,1,-1
          ELSE
             EXIT main
          ENDIF
- 
+
       ENDDO main
- 
-! Now check that we do not have a situation where a comment was entered on a card that was not the last card of the set.
-! If the last character in ALL_SETS_ARRAY is a comma, then we give fatal error
+
+      ! Now check that we do not have a situation where a comment was
+      ! entered on a card that was not the last card of the set.
+      ! If the last character in ALL_SETS_ARRAY is a comma, then we
+      ! give fatal error
 
 i_do5:DO I=SETLEN,1,-1
          IF      (ALL_SETS_ARRAY(I) == ' ') THEN
@@ -277,21 +277,19 @@ i_do5:DO I=SETLEN,1,-1
       TOKSTR_PART(1:TOKLEN) = TOKSTR_WHOLE(DATA_BEG:DATA_END)
  
 ! **********************************************************************************************************************************
-! Check syntax of this set data
- 
+      ! Check syntax of this set data
       ISTART = 1
       THRU   = 'OFF'
       EXCEPT = 'OFF'
       DO
  
-! Call STOKEN in a DO loop until we run out of tokens in TOKSTR_PART. We run out of data in the set when ISTART > TOKLEN
+         ! Call STOKEN in a DO loop until we run out of tokens in TOKSTR_PART.
+         ! We run out of data in the set when ISTART > TOKLEN
  
          CALL STOKEN ( SUBR_NAME, TOKSTR_PART, ISTART, TOKLEN, NTOKEN, IERROR, TOKTYP, TOKEN, ERRTOK, THRU, EXCEPT )
- 
-! Error: too long a token in the set definition
- 
-         IF (IERROR == 1) THEN
 
+         ! Error: too long a token in the set definition
+         IF (IERROR == 1) THEN
             FATAL_ERR = FATAL_ERR + 1
 
             WRITE(ERR,1252) SETID
@@ -330,9 +328,8 @@ i_do5:DO I=SETLEN,1,-1
             WRITE(F06,*)
 
             EXIT
- 
-! Error: found "EXCEPT" but EXCEPT has already been turned "ON "
- 
+
+         ! Error: found "EXCEPT" but EXCEPT has already been turned "ON "
          ELSE IF (IERROR == 3) THEN
 
             FATAL_ERR = FATAL_ERR + 1

--- a/Source/LK1/L1A-CC/CC_SET0.f90
+++ b/Source/LK1/L1A-CC/CC_SET0.f90
@@ -135,7 +135,7 @@
          ENDDO 
  
          IF (ICONT == 1) THEN
-            READ(IN1,101,IOSTAT=IOCHK) CARD1
+            CALL READ_BDF_LINE(IN1, IOCHK, CARD1)
             IF (IOCHK > 0) THEN
                RETURN
             ENDIF

--- a/Source/LK1/L1A/LOADB.f90
+++ b/Source/LK1/L1A/LOADB.f90
@@ -26,8 +26,7 @@
  
       SUBROUTINE LOADB
  
-! LOADB reads in the Bulk Data deck.
- 
+      ! LOADB reads in the Bulk Data deck.
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, F06, IN1
       USE SCONTR, ONLY                :  BD_ENTRY_LEN, BLNK_SUB_NAM, ECHO, FATAL_ERR, IMB_BLANK, JF, LIND_GRDS_MPCS,               &
@@ -99,8 +98,7 @@
       ENDIF
 
 ! **********************************************************************************************************************************
-! Initialize
-
+      ! Initialize
       IOR3D_MAX = 0
 
       IF (SPCSET == 0) THEN
@@ -115,22 +113,20 @@
          CC_MPC_FND = 'N'
       ENDIF
 
-! Initialize CC_LOAD_FND
-
-!  CC_LOAD_FND = Character array containing 'Y' or 'N' indicating whether the load
-!           or temperature load requested in Case Control was found in B.D.deck.
-!           Each row has the following indicators for 1 subcase 
-!            (1) Col 1: indicators for Case Control LOAD
-!            (2) Col 2: indicators for Case Control TEMP
-!            (a) CC_LOAD_FND(I,1) = '0' if there were no LOAD requests in Case Control
-!                            = 'N' if there were LOAD requests in Case Control
-!            (b) CC_LOAD_FND(I,2) = '0' if there were no TEMP requests in Case Control  
-!                            = 'N' if there were TEMP requests in Case Control
-!           Subroutines BD_FORMOM, BD_GRAV, BD_LOAD, BD_PLOAD2, BD_TEMP, BD_TEMPD, BD_TEMPRP
-!           reset CC_LOAD_FND to 'Y' if a load (or temp) with set ID matching one in a
-!           Case Control request is found.
-
-  
+      ! Initialize CC_LOAD_FND
+      
+      !  CC_LOAD_FND = Character array containing 'Y' or 'N' indicating whether the load
+      !           or temperature load requested in Case Control was found in B.D.deck.
+      !           Each row has the following indicators for 1 subcase 
+      !            (1) Col 1: indicators for Case Control LOAD
+      !            (2) Col 2: indicators for Case Control TEMP
+      !            (a) CC_LOAD_FND(I,1) = '0' if there were no LOAD requests in Case Control
+      !                            = 'N' if there were LOAD requests in Case Control
+      !            (b) CC_LOAD_FND(I,2) = '0' if there were no TEMP requests in Case Control  
+      !                            = 'N' if there were TEMP requests in Case Control
+      !           Subroutines BD_FORMOM, BD_GRAV, BD_LOAD, BD_PLOAD2, BD_TEMP, BD_TEMPD, BD_TEMPRP
+      !           reset CC_LOAD_FND to 'Y' if a load (or temp) with set ID matching one in a
+      !           Case Control request is found.
       DO I=1,NSUB
          IF (SUBLOD(I,1) == 0) THEN
             CC_LOAD_FND(I,1) = '0'
@@ -154,25 +150,25 @@
       MELGP         = 2                                    ! This max num grids/elem DOF's covers all 2 node/6 comp per node elems
       MELDOF        = 12                                   ! (other elems will be checked and MELGP, MELDOF reset if necessary)
 
-! Process Bulk Data cards in a large loop that runs until either an ENDDATA card is found or when an error or EOF/EOR occurs
-
+      ! Process Bulk Data cards in a large loop that runs until either an 
+      ! ENDDATA card is found or when an error or EOF/EOR occurs
 bdf:  DO
 
-         READ(IN1,101,IOSTAT=IOCHK) CARD1
-         CARD(1:) = CARD1(1:)                              ! Must have this since CARD goes to BD_xxxx, not CARD1.
-!                                                            This will get reset if CARD1 is a large field format
+         CALL READ_BDF_LINE(IN1, IOCHK, CARD1)
+
+         ! Must have this since CARD goes to BD_xxxx, not CARD1.
+         ! This will get reset if CARD1 is a large field format
+         CARD(1:) = CARD1(1:)
  
-! Quit if EOF/EOR occurs.
- 
+         ! Quit if EOF/EOR occurs.
          IF (IOCHK < 0) THEN
             WRITE(ERR,1011) END_CARD
             WRITE(F06,1011) END_CARD
             FATAL_ERR = FATAL_ERR + 1
             CALL OUTA_HERE ( 'Y' )
          ENDIF
- 
-! Check if error occurs.
- 
+
+         ! Check if error occurs.
          IF (IOCHK > 0) THEN
             WRITE(ERR,1010) DECK_NAME
             WRITE(F06,1010) DECK_NAME
@@ -180,15 +176,13 @@ bdf:  DO
             FATAL_ERR = FATAL_ERR + 1
             CYCLE
          ENDIF
- 
-! Write out BULK DATA card.
- 
+
+         ! Write out BULK DATA card.
          IF (ECHO /= 'NONE  ') THEN
             WRITE(F06,101) CARD1
          ENDIF
  
-! Remove any comments within the card by deleting everything from $ on (after col 1)
-
+         ! Remove any comments within the card by deleting everything from $ on (after col 1)
          COMMENT_COL = 1
          DO I=2,BD_ENTRY_LEN
             IF (CARD1(I:I) == '$') THEN
@@ -201,8 +195,7 @@ bdf:  DO
             CARD1(COMMENT_COL:) = ' '
          ENDIF
 
-! Determine if the card is large or small format
-
+         ! Determine if the card is large or small format
          LARGE_FLD_INP = 'N'
          DO I=1,8
             IF (CARD1(I:I) == '*') THEN
@@ -210,18 +203,17 @@ bdf:  DO
             ENDIF
          ENDDO
 
-! FFIELD converts free-field card to fixed field and left justifies the data in fields 2-9 and outputs a 10 field, 16 col/field CARD
- 
+         ! FFIELD converts free-field card to fixed field and left justifies
+         ! the data in fields 2-9 and outputs a 10 field, 16 col/field CARD
          IF ((CARD1(1:1) /= '$') .AND. (CARD1(1:) /= ' ')) THEN
 
             IF (LARGE_FLD_INP == 'N') THEN
-
                CALL FFIELD ( CARD1, IERR )
                CARD(1:) = CARD1(1:)
 
             ELSE
-
-               READ(IN1,101,IOSTAT=IOCHK) CARD2            ! Read 2nd physical entry for a large field parent B.D. entry
+               ! Read 2nd physical entry for a large field parent B.D. entry
+               CALL READ_BDF_LINE(IN1, IOCHK, CARD1)
  
                IF (IOCHK < 0) THEN
                   WRITE(ERR,1011) END_CARD
@@ -289,8 +281,7 @@ bdf:  DO
 
          ENDIF
  
-! Process Bulk Data card
-
+         ! Process Bulk Data card
          IF((     CARD(1:5) == 'ASET '   ) .OR. (CARD(1:5) == 'ASET*'   ) .OR.                                                     &
                  (CARD(1:5) == 'OMIT '   ) .OR. (CARD(1:5) == 'OMIT*'   )) THEN 
             CALL BD_ASET    ( CARD )
@@ -924,10 +915,12 @@ j_do2:            DO J=2,LMPCADDC
             ENDDO
 
 
-! (d) Check for duplicate MPC set ID's on MPCADD. There was a check on each MPCADD entry read in subr BD_MPCADD but no check was
-!     made across duplicate MPCADD entries (i.e. there may be more than 1 MPCADD entry with the same set ID and we need to make
-!     sure that an MPC set ID on the 2nd, etc, is not the same as one on the 1st, etc)
-
+            ! (d) Check for duplicate MPC set ID's on MPCADD. There was a
+            !     check on each MPCADD entry read in subr BD_MPCADD but no
+            !     check was made across duplicate MPCADD entries (i.e. 
+            !     there may be more than 1 MPCADD entry with the same set ID
+            !     and we need to make sure that an MPC set ID on the 2nd, etc.,
+            !     is not the same as one on the 1st, etc)
             CALL SORT_INT1 ( SUBR_NAME, 'MPCSIDS', NUM_MPCSIDS, MPCSIDS )
             DO I=2,NUM_MPCSIDS
                IF (MPCSIDS(I) == MPCSIDS(I-1)) THEN
@@ -941,8 +934,8 @@ j_do2:            DO J=2,LMPCADDC
 
       ENDIF
 
-! Check if load (LOAD, FORCE, MOMENT, GRAV, TEMP, etc.) Bulk Data cards with SID matching Case Control were found
-  
+      ! Check if load (LOAD, FORCE, MOMENT, GRAV, TEMP, etc.) Bulk Data cards
+      ! with SID matching Case Control were found
       DO I=1,NSUB
         IF (CC_LOAD_FND(I,1) == 'N') THEN
            WRITE(ERR,1007) SUBLOD(I,1)
@@ -955,9 +948,9 @@ j_do2:            DO J=2,LMPCADDC
            FATAL_ERR = FATAL_ERR + 1
         ENDIF
       ENDDO   
-  
-! Check to make sure that all forces, moments and GRAV cards requested on LOAD Bulk Data cards are in the deck
-  
+
+      ! Check to make sure that all forces, moments and GRAV cards requested
+      ! on LOAD Bulk Data cards are in the deck
       DO I=1,NLOAD
          DO J=1,NSUB
             IF (LOAD_SIDS(I,1) == SUBLOD(J,1)) THEN
@@ -994,15 +987,12 @@ j_do2:            DO J=2,LMPCADDC
                      WRITE(F06,1009) LOAD_SIDS(I,K),LOAD_SIDS(I,1),SCNUM(J)
                      FATAL_ERR = FATAL_ERR + 1
                   ENDIF
-               ENDDO   
+               ENDDO
             ENDIF
          ENDDO
-      ENDDO   
+      ENDDO
 
-
-
-! Write message regarding max number of elem grids/DOF's
-
+      ! Write message regarding max number of elem grids/DOF's
       MDT = MAX(MTDAT_TEMPP1, MTDAT_TEMPRB, MELGP+3, 5)    
       WRITE(F06,*)
       WRITE(ERR,1197) MELGP, MELDOF
@@ -1149,3 +1139,43 @@ j_do2:            DO J=2,LMPCADDC
       END SUBROUTINE CALC_MAX_GAUSS_POINTS
 
       END SUBROUTINE LOADB
+
+
+      !function to_upper(in) result (out)
+      SUBROUTINE TO_UPPER_LINE(LINE)
+      ! it seems like there should be a better way to write an upper function...
+      ! https://en.wikibooks.org/wiki/Fortran/strings
+      implicit none
+      CHARACTER(256), intent (inout) :: LINE
+      integer                    :: I, J
+      CHARACTER(26), parameter   :: UPP = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+      CHARACTER(26), parameter   :: LOW = 'abcdefghijklmnopqrstuvwxyz'
+      
+      DO I = 1,256
+          J = index(LOW, LINE(I:I))      ! Is ith character in LOW
+          IF (J>0) LINE(I:I) = UPP(J:J)  ! Yes, then subst with UPP
+      ENDDO
+      END SUBROUTINE TO_UPPER_LINE
+      !end function to_upper
+
+      !---------------------------------------------------------
+      SUBROUTINE READ_BDF_LINE(IN1, IOCHK, LINE)
+      
+      ! it seems like there should be a better way to write an upper function...
+      ! https://en.wikibooks.org/wiki/Fortran/strings
+      USE IOUNT1, ONLY                :  ERR !, F04, F06, IN1
+      implicit none
+      CHARACTER(256), intent (inout) :: LINE
+      integer, intent (in)       :: IN1
+      integer, intent (inout)    :: IOCHK
+      integer                    :: I, J
+      CHARACTER(26), parameter   :: UPP = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+      CHARACTER(26), parameter   :: LOW = 'abcdefghijklmnopqrstuvwxyz'
+      READ(IN1,101,IOSTAT=IOCHK) LINE
+      DO I = 1,256
+          J = index(LOW, LINE(I:I))      ! Is ith character in LOW
+          IF (J>0) LINE(I:I) = UPP(J:J)  ! Yes, then subst with UPP
+      ENDDO
+
+  101 FORMAT(A)
+      END SUBROUTINE READ_BDF_LINE

--- a/Source/LK1/L1A/LOADB0.f90
+++ b/Source/LK1/L1A/LOADB0.f90
@@ -23,12 +23,11 @@
 ! _______________________________________________________________________________________________________
                                                                                                         
 ! End MIT license text.                                                                                      
- 
+
       SUBROUTINE LOADB0
- 
-! Preliminary reading of the Bulk Data to count several data sizes so that arrays may be allocated prior to the final reading
-! of the Bulk Data.
- 
+
+      ! Preliminary reading of the Bulk Data to count several data sizes so
+      ! that arrays may be allocated prior to the final reading of the Bulk Data.
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, F06, IN1                
       USE SCONTR, ONLY                :  BD_ENTRY_LEN, BLNK_SUB_NAM, FATAL_ERR, LCMASS, LDOFG, LELE,                               &
@@ -104,20 +103,18 @@
       DO
 
          ICNT = ICNT + 1
-         READ(IN1,101,IOSTAT=IOCHK) CARD1
+         CALL READ_BDF_LINE(IN1, IOCHK, CARD1)
          CARD(1:)  = CARD1(1:)
- 
-! Quit if EOF/EOR occurs.
- 
+
+         ! Quit if EOF/EOR occurs.
          IF (IOCHK < 0) THEN
             WRITE(ERR,1011) END_CARD
             WRITE(F06,1011) END_CARD
             FATAL_ERR = FATAL_ERR + 1
             CALL OUTA_HERE ( 'Y' )
          ENDIF
- 
-! Check if error occurs.
- 
+
+         ! Check if error occurs.
          IF (IOCHK > 0) THEN
             WRITE(ERR,1010) DECK_NAME
             WRITE(F06,1010) DECK_NAME
@@ -125,9 +122,9 @@
             FATAL_ERR = FATAL_ERR + 1
             CYCLE
          ENDIF
- 
-! Remove any comments within the CARD1 by deleting everything from $ on (after col 1)
 
+         ! Remove any comments within the CARD1 by deleting everything
+         ! from $ on (after col 1)
          COMMENT_COL = 1
          DO I=2,BD_ENTRY_LEN
             IF (CARD1(I:I) == '$') THEN
@@ -140,8 +137,7 @@
             CARD1(COMMENT_COL:) = ' '
          ENDIF
 
-! Determine if the card is large or small format
-
+         ! Determine if the card is large or small format
          LARGE_FLD_INP = 'N'
          DO I=1,8
             IF (CARD1(I:I) == '*') THEN
@@ -149,9 +145,9 @@
             ENDIF
          ENDDO
 
-! FFIELD converts free-field card to fixed field and left justifies data in fields 2-9 and outputs a 10 field, 16 col/field CARD1
- 
-         IF ((CARD1(1:1) /= '$')  .AND. (CARD1(1:) /= ' ')) THEN
+         ! FFIELD converts free-field card to fixed field and left justifies
+         ! data in fields 2-9 and outputs a 10 field, 16 col/field CARD1
+          IF ((CARD1(1:1) /= '$')  .AND. (CARD1(1:) /= ' ')) THEN
 
             IF (LARGE_FLD_INP == 'N') THEN
 
@@ -160,8 +156,9 @@
 
             ELSE
 
-               READ(IN1,101,IOSTAT=IOCHK) CARD2            ! Read 2nd physical entry for a large field parent B.D. entry
- 
+               ! Read 2nd physical entry for a large field parent B.D. entry
+               CALL READ_BDF_LINE(IN1, IOCHK, CARD2)
+
                IF (IOCHK < 0) THEN
                   WRITE(ERR,1011) END_CARD
                   WRITE(F06,1011) END_CARD
@@ -217,9 +214,9 @@
 
          ENDIF
  
-! No errors, so process Bulk Data card. No need to check for imbedded blanks found when FFIELD was run - this will be
-! checked when LOADB reads the bulk data
-
+          ! No errors, so process Bulk Data card. No need to check for
+          ! imbedded blanks found when FFIELD was run - this will be
+          ! checked when LOADB reads the bulk data
           IF      (CARD(1:5) == 'BAROR'   )  THEN
             CALL BD_BAROR0 ( CARD )
 

--- a/Source/LK1/L1A/LOADB_RESTART.f90
+++ b/Source/LK1/L1A/LOADB_RESTART.f90
@@ -25,9 +25,9 @@
 ! End MIT license text.                                                                                      
  
       SUBROUTINE LOADB_RESTART
- 
-! LOADB_RESTART reads in some entries in the Bulk Data deck (e.g. DEBUG, PARAM) for a RESTART run
- 
+
+      ! LOADB_RESTART reads in some entries in the Bulk Data deck
+      ! (e.g., DEBUG, PARAM) for a RESTART run
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, F06, IN1
       USE SCONTR, ONLY                :  BD_ENTRY_LEN, BLNK_SUB_NAM, ECHO, FATAL_ERR, JCARD_LEN, JF, PROG_NAME, WARN_ERR
@@ -134,23 +134,21 @@
 
       WRITE(F06,100)
 
-! Process Bulk Data cards in a large loop that runs until either an ENDDATA card is found or when an error or EOF/EOR occurs
-    
+      ! Process Bulk Data cards in a large loop that runs until either an
+      ! ENDDATA card is found or when an error or EOF/EOR occurs
       DO
-         READ(IN1,101,IOSTAT=IOCHK) CARD1
+         CALL READ_BDF_LINE(IN1, IOCHK, CARD1)
          CARD(1:) = CARD1(1:)
- 
-! Quit if EOF/EOR occurs.
- 
+
+         ! Quit if EOF/EOR occurs.
          IF (IOCHK < 0) THEN
             WRITE(ERR,1011) END_CARD
             WRITE(F06,1011) END_CARD
             FATAL_ERR = FATAL_ERR + 1
             CALL OUTA_HERE ( 'Y' )
          ENDIF
- 
-! Check if error occurs.
- 
+
+         ! Check if error occurs.
          IF (IOCHK > 0) THEN
             WRITE(ERR,1010) DECK_NAME
             WRITE(F06,1010) DECK_NAME
@@ -159,8 +157,8 @@
             CYCLE
          ENDIF
  
-! Remove any comments within the CARD1 by deleting everything from $ on (after col 1)
-
+         ! Remove any comments within the CARD1 by deleting everything
+         ! from $ on (after col 1)
          COMMENT_COL = 1
          DO I=2,BD_ENTRY_LEN
             IF (CARD1(I:I) == '$') THEN
@@ -173,8 +171,7 @@
             CARD1(COMMENT_COL:) = ' '
          ENDIF
 
-! Determine if the card is large or small format
-
+         ! Determine if the card is large or small format
          LARGE_FLD_INP = 'N'
          DO I=1,8
             IF (CARD1(I:I) == '*') THEN
@@ -182,8 +179,8 @@
             ENDIF
          ENDDO
 
-! FFIELD converts free-field card to fixed field and left justifies data in fields 2-9 and outputs a 10 field, 16 col/field CARD1
- 
+         ! FFIELD converts free-field card to fixed field and left justifies
+         ! data in fields 2-9 and outputs a 10 field, 16 col/field CARD1
          IF ((CARD1(1:1) /= '$')  .AND. (CARD1(1:) /= ' ')) THEN
 
             IF (LARGE_FLD_INP == 'N') THEN
@@ -192,9 +189,9 @@
                CARD(1:) = CARD1(1:)
 
             ELSE
+               ! Read 2nd physical entry for a large field parent B.D. entry
+               CALL READ_BDF_LINE(IN1, IOCHK, CARD2)
 
-               READ(IN1,101,IOSTAT=IOCHK) CARD2            ! Read 2nd physical entry for a large field parent B.D. entry
- 
                IF (IOCHK < 0) THEN
                   WRITE(ERR,1011) END_CARD
                   WRITE(F06,1011) END_CARD
@@ -242,11 +239,10 @@
             ENDIF 
 
          ENDIF
- 
-! Process Bulk Data card
 
+         ! Process Bulk Data card
          CALL MKJCARD ( SUBR_NAME, CARD, JCARD )
- 
+
          IF      ((JCARD(1)(1:6) == 'DEBUG ') .OR. (JCARD(1)(1:6) == 'DEBUG*'))  THEN
             READ(JCARD(2),'(I8)') INDEX
             DO I=1,NUM_DEB

--- a/Source/LK1/L1A/LOADC.f90
+++ b/Source/LK1/L1A/LOADC.f90
@@ -65,22 +65,22 @@
 
 ! **********************************************************************************************************************************
 
-! Process CASE CONTROL DECK
+      ! Process CASE CONTROL DECK
 
 outer:DO
          DOLLAR_WARN = 'N'
-         READ(IN1,101,IOSTAT=IOCHK) CARD
+         CALL READ_BDF_LINE(IN1, IOCHK, CARD)
 
          ! Quit if EOF/EOR occurs during read
- 
          IF (IOCHK < 0) THEN
             WRITE(ERR,1011) END_CARD
             WRITE(F06,1011) END_CARD
             FATAL_ERR = FATAL_ERR + 1
             CALL OUTA_HERE ( 'Y' )
          ENDIF
- 
-         IF (IOCHK > 0) THEN                               ! Check if error occurs during read.
+
+         ! Check if error occurs during read.
+         IF (IOCHK > 0) THEN
             WRITE(ERR,1010) DECK_NAME
             WRITE(F06,1010) DECK_NAME
             WRITE(F06,'(A)') CARD 
@@ -90,12 +90,13 @@ outer:DO
  
          WRITE(F06,101) CARD
 
-         CALL REPLACE_TABS_W_BLANKS ( CARD )               ! Replace all tab characters with a white space
+         ! Replace all tab characters with a white space
+         CALL REPLACE_TABS_W_BLANKS ( CARD )
 
-         CALL CSHIFT ( CARD, ' ', CARD1, CHAR_COL, IERR )  ! Shift card so that it begins in col 1
+         ! Shift card so that it begins in col 1
+         CALL CSHIFT ( CARD, ' ', CARD1, CHAR_COL, IERR )
 
-! Check for CASE CONTROL cards. Exit loop on 'BEGIN BULK'
-
+         ! Check for CASE CONTROL cards. Exit loop on 'BEGIN BULK'
          IF      (CARD1(1:4) == 'ACCE'    ) THEN
             CALL CC_ACCE ( CARD1 )
  
@@ -165,8 +166,11 @@ outer:DO
                WARN_ERR = WARN_ERR + 1
                WRITE(ERR,902) CARD
                WRITE(F06,902) CARD
-inner:         DO                                          ! so read all entries up to BEGIN BULK and then exit loop for CC entries 
+
+               ! so read all entries up to BEGIN BULK and then exit loop for CC entries
+inner:         DO
                   READ(IN1,101) CARD
+                  CALL TO_UPPER_LINE(CARD)
                   IF (CARD(1:10) == 'BEGIN BULK') THEN
                      WRITE(F06,101) CARD
                      EXIT outer

--- a/Source/LK1/L1A/LOADC0.f90
+++ b/Source/LK1/L1A/LOADC0.f90
@@ -26,12 +26,14 @@
  
       SUBROUTINE LOADC0
  
-! Preliminary reading of the Case Control to count several data sizes so that arrays may be allocated prior to the final reading
-! of the Case Control.
-
-! LOADC0 reads in the CASE CONTROL DECK and:
-!   1) Counts the number of subcases and increments LSUB
-!   2) Counts the number of SET cards and calls CC_SET0 to count the number of characters in SET's to determine LSETLN
+      ! Preliminary reading of the Case Control to count several data sizes
+      ! so that arrays may be allocated prior to the final reading of the
+      ! Case Control.
+      !
+      ! LOADC0 reads in the CASE CONTROL DECK and:
+      !   1) Counts the number of subcases and increments LSUB
+      !   2) Counts the number of SET cards and calls CC_SET0 to count the
+      !      number of characters in SET's to determine LSETLN
  
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  WRT_LOG, ERR, F04, F06, IN1
@@ -63,20 +65,18 @@
       ENDIF
 
 ! **********************************************************************************************************************************
-! Initialize
-
+      ! Initialize
       JERR     = 0
       END_CARD = 'CEND      '
 
-! Process CASE CONTROL DECK
- 
+      ! Process CASE CONTROL DECK
       JERR = 0
       END_CARD = 'BEGIN BULK'
 
       DO
+         ! Read an input deck card
+         CALL READ_BDF_LINE(IN1, IOCHK, CARD)
 
-         READ(IN1,101,IOSTAT=IOCHK) CARD                   ! Read an input deck card
- 
          IF (IOCHK < 0) THEN                               ! Quit if EOF/EOR occurs during read
             WRITE(ERR,1011) END_CARD  
             WRITE(F06,1011) END_CARD  
@@ -96,8 +96,7 @@
 
          CALL CSHIFT ( CARD, ' ', CARD1, CHAR_COL, IERR )  ! Shift CARD so it begins in col 1
 
-! Check for Case Control cards. Exit loop on 'BEGIN BULK'
- 
+         ! Check for Case Control cards. Exit loop on 'BEGIN BULK'
          IF      (CARD1(1: 4) == 'SUBC'      ) THEN
             LSUB = LSUB + 1
 
@@ -108,11 +107,10 @@
          ELSE IF (CARD1(1:10) == 'BEGIN BULK') THEN
             EXIT
          ENDIF
- 
+
       ENDDO
- 
-! If there were no explicit subcases, then default LSUB to 1
- 
+
+      ! If there were no explicit subcases, then default LSUB to 1
       IF (LSUB == 0) THEN
          LSUB = 1
       ENDIF
@@ -122,7 +120,7 @@
          WRITE(F06,10141)
          CALL OUTA_HERE ( 'Y' )
       ENDIF
- 
+
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN
          CALL OURTIM

--- a/Source/LK1/L1A/LOADE.f90
+++ b/Source/LK1/L1A/LOADE.f90
@@ -106,9 +106,8 @@
 ! Process EXECUTIVE CONTROL DECK
  
       DO
- 
-         READ(IN1,101,IOSTAT=IOCHK) CARD
- 
+         CALL READ_BDF_LINE(IN1, IOCHK, CARD)
+
          IF (IOCHK < 0) THEN                               ! Quit if EOF/EOR occurs during read
             WRITE(ERR,1011) END_CARD
             WRITE(F06,1011) END_CARD

--- a/Source/LK1/L1A/LOADE0.f90
+++ b/Source/LK1/L1A/LOADE0.f90
@@ -26,8 +26,8 @@
  
       SUBROUTINE LOADE0
  
-! LOADE0 does a preliminary read of the EXEC CONTROL DECK to find if there is a RESTART entry
- 
+      ! LOADE0 does a preliminary read of the EXEC CONTROL DECK to find
+      ! if there is a RESTART entry
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  ERR, F04, F06, FILE_NAM_MAXLEN, IN0, IN1, INC, LEN_INPUT_FNAME, INFILE,           &
                                          LEN_RESTART_FNAME, LNUM_IN4_FILES, RESTART_FILNAM, SCR, WRT_LOG
@@ -62,15 +62,13 @@
       ENDIF
 
 ! **********************************************************************************************************************************
-! Initialize
-
+      ! Initialize
       LNUM_IN4_FILES = 0
-		RESTART        = 'N'
+      RESTART        = 'N'
 
 !xx   REWIND (IN1)
 main: DO
-
-         READ(IN1,101,IOSTAT=IOCHK) CARD
+         CALL READ_BDF_LINE(IN1, IOCHK, CARD)
 
          IF (IOCHK < 0) THEN                               ! Quit if EOF/EOR occurs during read
             WRITE(ERR,1011) END_CARD

--- a/Source/LK1/L1U/NEXTC.f90
+++ b/Source/LK1/L1U/NEXTC.f90
@@ -142,8 +142,6 @@
       CALL MKJCARD ( SUBR_NAME, TCARD, JCARD )
       NEWTAG = JCARD(1)
       
-      !WRITE(ERR,*) 'tags',OLDTAG,NEWTAG
-      
       IF (NEWTAG == OLDTAG) THEN
          ICONTINUE = 1
       ELSE IF ((OLDTAG(1:1) == '+') .AND. (NEWTAG(1:1) == ' ') .AND. (OLDTAG(2:8) == NEWTAG(2:8))) THEN

--- a/Source/LK1/L1U/NEXTC.f90
+++ b/Source/LK1/L1U/NEXTC.f90
@@ -88,7 +88,7 @@
       MESSAG = 'BULK DATA CARD          '
 
       ! Read next card
-      READ(IN1,101,IOSTAT=IOCHK) TCARD
+      CALL READ_BDF_LINE(IN1, IOCHK, TCARD)
       CARD_IN = TCARD
       IF (IOCHK /= 0) THEN
          REC_NO = -99
@@ -103,7 +103,8 @@
       ! NOTE: comment lines must start with a $, so a space is
       !       not considered a comment
       DO WHILE (TCARD(1:1) == '$') 
-         READ(IN1,101,IOSTAT=IOCHK) TCARD  ! Read next card
+         ! Read next card line
+         CALL READ_BDF_LINE(IN1, IOCHK, TCARD)
          CARD_IN = TCARD
          IF (IOCHK /= 0) THEN
             REC_NO = -99
@@ -131,45 +132,47 @@
       !
       ! get a flag (ICONTINUE) that defines if we need to read the next line
       ! we do because we have OLDTAG
-      IF (TCARD(1:1) /= '$') THEN
-         CALL FFIELD ( TCARD, IERR )
 
-         ! split the continuation line (TCARD) into fields (JCARD)
-         CALL MKJCARD ( SUBR_NAME, TCARD, JCARD )
-         NEWTAG = JCARD(1)
-         IF (NEWTAG == OLDTAG) THEN
-            ICONTINUE = 1
-         ELSE IF ((OLDTAG(1:1) == '+') .AND. (NEWTAG(1:1) == ' ') .AND. (OLDTAG(2:8) == NEWTAG(2:8))) THEN
-            ICONTINUE = 1
-         ELSE IF ((OLDTAG(1:1) == ' ') .AND. (NEWTAG(1:1) == '+') .AND. (OLDTAG(2:8) == NEWTAG(2:8))) THEN
-            ICONTINUE = 1
-         ELSE
-            ! can\t find the continuation marker.  FATAL :)
-            BACKSPACE(IN1)
-            WRITE(F06,102) OLDTAG
-            WRITE(ERR,102) OLDTAG
-            WRITE(F06,103)
-            WRITE(ERR,103)
-            WRITE(F06,104) 'FIELDS1:', JCARD0
-            WRITE(ERR,104) 'FIELDS1:', JCARD0
-            WRITE(F06,104) 'FIELDS2:', JCARD
-            WRITE(ERR,104) 'FIELDS2:', JCARD
-            FLUSH(F06)
-            FLUSH(ERR)
-            FATAL_ERR = FATAL_ERR + 1
-            CALL OUTA_HERE('Y')  ! FATAL error
-            RETURN
-         ENDIF
-         !WRITE(ERR,*) 'OLDTAG="', OLDTAG, '"'
-         !WRITE(ERR,*) 'NEWTAG="', NEWTAG, '"'
-         !WRITE(ERR,*) 'ICONTINUE=', ICONTINUE
-         CARD = TCARD
-         IF (ECHO(1:4) /= 'NONE') THEN
-             WRITE(F06,'(A)') CARD_IN
-         ENDIF
-      ELSE
-         ! comment line
+      ! we know know that the line doesn't start with a $, but it
+      ! can be a different card (OLDTAG /= NEWTAG)
+      !
+      CALL FFIELD ( TCARD, IERR )
+
+      ! split the continuation line (TCARD) into fields (JCARD)
+      CALL MKJCARD ( SUBR_NAME, TCARD, JCARD )
+      NEWTAG = JCARD(1)
+      
+      !WRITE(ERR,*) 'tags',OLDTAG,NEWTAG
+      
+      IF (NEWTAG == OLDTAG) THEN
+         ICONTINUE = 1
+      ELSE IF ((OLDTAG(1:1) == '+') .AND. (NEWTAG(1:1) == ' ') .AND. (OLDTAG(2:8) == NEWTAG(2:8))) THEN
+         ICONTINUE = 1
+      ELSE IF ((OLDTAG(1:1) == ' ') .AND. (NEWTAG(1:1) == '+') .AND. (OLDTAG(2:8) == NEWTAG(2:8))) THEN
+         ICONTINUE = 1
+      ELSE IF ((NEWTAG(1:1) /= ' ') .AND. (NEWTAG(1:1) /= '+') .AND. (NEWTAG(1:1) /= '$')) THEN
+         ! different card type (e.g., LOAD -> FORCE
          BACKSPACE(IN1)
+      ELSE
+         ! can\t find the continuation marker.  FATAL :)
+         BACKSPACE(IN1)
+         WRITE(F06,102) OLDTAG
+         WRITE(ERR,102) OLDTAG
+         WRITE(F06,103)
+         WRITE(ERR,103)
+         WRITE(F06,104) 'FIELDS1:', JCARD0
+         WRITE(ERR,104) 'FIELDS1:', JCARD0
+         WRITE(F06,104) 'FIELDS2:', JCARD
+         WRITE(ERR,104) 'FIELDS2:', JCARD
+         FLUSH(F06)
+         FLUSH(ERR)
+         FATAL_ERR = FATAL_ERR + 1
+         CALL OUTA_HERE('Y')  ! FATAL error
+         RETURN
+      ENDIF
+      CARD = TCARD
+      IF (ECHO(1:4) /= 'NONE') THEN
+          WRITE(F06,'(A)') CARD_IN
       ENDIF
 
 ! **********************************************************************************************************************************

--- a/Source/LK1/L1U/NEXTC0.f90
+++ b/Source/LK1/L1U/NEXTC0.f90
@@ -64,33 +64,29 @@
       ENDIF
 
 ! **********************************************************************************************************************************
-! Initialize error indicator and ICONT
-
+      ! Initialize error indicator and ICONT
       IERR  = 0
       ICONT = 0
 
-! Make units for writing errors the error file and output file
-
+      ! Make units for writing errors the error file and output file
       OUNT(1) = ERR
       OUNT(2) = F06
 
-! Make JCARD for parent CARD
-
+      ! Make JCARD for parent CARD
       CALL MKJCARD ( SUBR_NAME, CARD, JCARD )
 
-! Read next card. If it is the cont card for this parent, keep it. Otherwise backspace the input file.
-
+      ! Read next card. If it is the cont card for this parent, keep it.
+      ! Otherwise backspace the input file.
       OLDTAG = JCARD(10)
       MESSAG = 'BULK DATA CARD          '
-      READ(IN1,101,IOSTAT=IOCHK) TCARD
+      CALL READ_BDF_LINE(IN1, IOCHK, TCARD)
       IF (IOCHK /= 0) THEN
          REC_NO = -99
          CALL READERR ( IOCHK, INFILE, MESSAG, REC_NO, OUNT, 'Y' )
          FATAL_ERR = FATAL_ERR + 1
       ENDIF
 
-! Remove any comments within the CARD by deleting everything fro $ on (after col 1)
-
+      ! Remove any comments within the CARD by deleting everything fro $ on (after col 1)
       COMMENT_COL = 1
       DO I=2,BD_ENTRY_LEN
          IF (TCARD(I:I) == '$') THEN

--- a/Source/LK1/L1U/NEXTC2.f90
+++ b/Source/LK1/L1U/NEXTC2.f90
@@ -77,9 +77,9 @@
       CALL MKJCARD ( SUBR_NAME, PARENT, JCARD )
       OLDTAG(1:8) = JCARD(10)(1:8)
 
-! Read next card. If it is a continuation to the parent it will be the 1st half of the whole continuation
-
-      READ(IN1,101,IOSTAT=IOCHK) CHILD1
+      ! Read next card. If it is a continuation to the parent it will
+      ! be the 1st half of the whole continuation
+      CALL READ_BDF_LINE(IN1, IOCHK, CHILD1)
       IF (IOCHK /= 0) THEN
          REC_NO = -99
          CALL READERR ( IOCHK, INFILE, 'BULK DATA CARD', REC_NO, OUNT, 'Y' )
@@ -99,9 +99,8 @@
          RETURN
       ENDIF 
 
-! Read 2nd half of continuation entry, if it exists
-
-      READ(IN1,101,IOSTAT=IOCHK) CHILD2
+      ! Read 2nd half of continuation entry, if it exists
+      CALL READ_BDF_LINE(IN1, IOCHK, CHILD2)
       IF (IOCHK /= 0) THEN
          REC_NO = -99
          CALL READERR ( IOCHK, INFILE, 'BULK DATA CARD', REC_NO, OUNT, 'Y' )

--- a/Source/LK1/L1U/NEXTC20.f90
+++ b/Source/LK1/L1U/NEXTC20.f90
@@ -26,8 +26,8 @@
  
       SUBROUTINE NEXTC20 ( PARENT, ICONT, IERR, CHILD )
  
-! Looks for 2 physical Bulk Data large field format continuation entries belonging to a large field parent.
-
+      ! Looks for 2 physical Bulk Data large field format continuation
+      ! entries belonging to a large field parent.
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  WRT_LOG, ERR, F04, F06, IN1, INFILE
       USE SCONTR, ONLY                :  BD_ENTRY_LEN, BLNK_SUB_NAM, ECHO, FATAL_ERR, JCARD_LEN
@@ -59,27 +59,24 @@
       INTEGER(LONG), PARAMETER        :: SUBR_BEGEND = NEXTC20_BEGEND
  
 ! **********************************************************************************************************************************
-! Initialize
-
+      ! Initialize
       CHILD(1:) = 'z'
       OLDTAG(1:) = ' '
 
       IERR  = 0
       ICONT = 0
 
-! Make units for writing errors the error file and output file
-
+      ! Make units for writing errors the error file and output file
       OUNT(1) = ERR
       OUNT(2) = F06
 
-! Make JCARD for PARENT and get the 1st 8 chars of field 10 (cont mnemonic)
-
+      ! Make JCARD for PARENT and get the 1st 8 chars of field 10 (cont mnemonic)
       CALL MKJCARD ( SUBR_NAME, PARENT, JCARD )
       OLDTAG(1:8) = JCARD(10)(1:8)
 
-! Read next card. If it is a continuation to the parent it will be the 1st half of the whole continuation
-
-      READ(IN1,101,IOSTAT=IOCHK) CHILD1
+      ! Read next card. If it is a continuation to the parent it will be
+      ! the 1st half of the whole continuation
+      CALL READ_BDF_LINE(IN1, IOCHK, CHILD1)
       IF (IOCHK /= 0) THEN
          REC_NO = -99
          CALL READERR ( IOCHK, INFILE, 'BULK DATA CARD', REC_NO, OUNT, 'Y' )
@@ -111,9 +108,8 @@
          RETURN
       ENDIF 
 
-! Read 2nd half of continuation entry, if it exists
-
-      READ(IN1,101,IOSTAT=IOCHK) CHILD2
+      ! Read 2nd half of continuation entry, if it exists
+      CALL READ_BDF_LINE(IN1, IOCHK, CHILD2)
       IF (IOCHK /= 0) THEN
          REC_NO = -99
          CALL READERR ( IOCHK, INFILE, 'BULK DATA CARD', REC_NO, OUNT, 'Y' )
@@ -138,9 +134,11 @@
       ENDIF 
 
 
-! Remove any comments within CHILD2 by deleting everything from $ on (after col 1). NOTE: CHILD1 cannot have  comments since the
-! last field is used for NEWTAG above
-
+      ! Remove any comments within CHILD2 by deleting everything from $ on
+      ! (after col 1).
+      !
+      ! NOTE: CHILD1 cannot have  comments since the last field is used for
+      ! NEWTAG above
       COMMENT_COL = 1
       DO I=2,BD_ENTRY_LEN
          IF (CHILD2(I:I) == '$') THEN
@@ -153,8 +151,7 @@
          CHILD2(COMMENT_COL:) = ' '
       ENDIF
 
-! Call FFIELD2 to put the 2 CHILDi's together and left justify
-
+      ! Call FFIELD2 to put the 2 CHILDi's together and left justify
       CALL FFIELD2 ( CHILD1, CHILD2, CHILD, IERR )
       ICONT = 1
 


### PR DESCRIPTION
added common READ_BDF_LINE subroutine; fixes #69
 - inside function, it uppercases the line so mystran is case insensitive
 - in the one place that the subroutine isn't called to_upper_line is used

fixed stricter NEXTC.f90 check (see #57) that had issues with
 - LOAD, ...
 - FORCE, ... 
icontinue was incorrect.  Simplified code added specific check to backspace to the previous line.  This seems to be fixed now, but we should run all the decks.  The big fix to this is seen in the "different card type" block from nextc.f90.

![image](https://github.com/MYSTRANsolver/MYSTRAN/assets/1059417/f35922da-c8d1-4b6d-8aae-f2fb5ebee62c)
