### PR TITLE
Runtime performance improvement for large problems

### DIFF
--- a/Source/EMG/EMG1/GET_ELEM_AGRID_BGRID.f90
+++ b/Source/EMG/EMG1/GET_ELEM_AGRID_BGRID.f90
@@ -72,6 +72,9 @@
 
       CALL GET_ELGP ( INT_ELEM_ID )
 
+      ! assert that the array is sorted and the binary search in GET_ARRAY_ROW_NUM will work
+      CALL ASSERT_ARRAY_SORTED ( 'GRID_ID', SUBR_NAME, NGRID, GRID_ID) 
+
       DO I=1,ELGP
          DELTA = 1
          IF (TYPE == 'BUSH    ') THEN                      ! 1st grid in EDAT for BUSH is at EPNTK+3 since "Num grids" is EPNTK+2

--- a/Source/Interfaces/GET_ARRAY_ROW_NUM_Interface.f90
+++ b/Source/Interfaces/GET_ARRAY_ROW_NUM_Interface.f90
@@ -52,7 +52,7 @@
  
       END SUBROUTINE GET_ARRAY_ROW_NUM
 
-      SUBROUTINE ASSERT_ARRAY_SORTED ( ARRAY_NAME, CALLING_SUBR, ASIZE, ARRAY, EXT_ID, ROW_NUM )
+      SUBROUTINE ASSERT_ARRAY_SORTED ( ARRAY_NAME, CALLING_SUBR, ASIZE, ARRAY)
 
          USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
          USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, f06
@@ -68,8 +68,6 @@
    
          INTEGER(LONG), INTENT(IN)       :: ASIZE             ! Size of ARRAY
          INTEGER(LONG), INTENT(IN)       :: ARRAY(ASIZE)      ! Array to search
-         INTEGER(LONG), INTENT(IN)       :: EXT_ID            ! External (actual) ID to find in ARRAY
-         INTEGER(LONG), INTENT(OUT)      :: ROW_NUM           ! Internal ID (row in ARRAY) where EXT_ID exists
          INTEGER(LONG)                   :: N                 ! Loop index
       END SUBROUTINE ASSERT_ARRAY_SORTED
    END INTERFACE

--- a/Source/Interfaces/GET_ARRAY_ROW_NUM_Interface.f90
+++ b/Source/Interfaces/GET_ARRAY_ROW_NUM_Interface.f90
@@ -52,6 +52,26 @@
  
       END SUBROUTINE GET_ARRAY_ROW_NUM
 
+      SUBROUTINE ASSERT_ARRAY_SORTED ( ARRAY_NAME, CALLING_SUBR, ASIZE, ARRAY, EXT_ID, ROW_NUM )
+
+         USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
+         USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, f06
+         USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR
+         
+         USE GET_ARRAY_ROW_NUM_USE_IFs
+   
+         IMPLICIT NONE
+    
+         CHARACTER(LEN=LEN(BLNK_SUB_NAM)):: SUBR_NAME = 'ASSERT_ARRAY_SORTED'
+         CHARACTER(LEN=*), INTENT(IN)    :: ARRAY_NAME        ! Name of array to be searched
+         CHARACTER(LEN=*), INTENT(IN)    :: CALLING_SUBR      ! Name of subr that called this one
+   
+         INTEGER(LONG), INTENT(IN)       :: ASIZE             ! Size of ARRAY
+         INTEGER(LONG), INTENT(IN)       :: ARRAY(ASIZE)      ! Array to search
+         INTEGER(LONG), INTENT(IN)       :: EXT_ID            ! External (actual) ID to find in ARRAY
+         INTEGER(LONG), INTENT(OUT)      :: ROW_NUM           ! Internal ID (row in ARRAY) where EXT_ID exists
+         INTEGER(LONG)                   :: N                 ! Loop index
+      END SUBROUTINE ASSERT_ARRAY_SORTED
    END INTERFACE
 
    END MODULE GET_ARRAY_ROW_NUM_Interface

--- a/Source/UTIL/GET_ARRAY_ROW_NUM.f90
+++ b/Source/UTIL/GET_ARRAY_ROW_NUM.f90
@@ -67,9 +67,9 @@
       INTEGER(LONG)                   :: N                 ! When the search is completed, N is the ROW_NUM we ara looking for
       INTEGER(LONG), PARAMETER        :: SUBR_BEGEND = GET_ARRAY_ROW_NUM_BEGEND
  
-      REAL(DOUBLE)                    :: DBL_N             ! Real value of (DBL_HI + DBL_LO + 1.D0)/2.D0
-      REAL(DOUBLE)                    :: DBL_HI            ! Real value of HI
-      REAL(DOUBLE)                    :: DBL_LO            ! Real value of LO
+      INTEGER(LONG)                   :: TMP_N             ! Real value of (DBL_HI + DBL_LO + 1.D0)/2.D0
+      INTEGER(LONG)                   :: TMP_HI            ! Real value of HI
+      INTEGER(LONG)                   :: TMP_LO            ! Real value of LO
 
       INTRINSIC                       :: FLOOR             ! Largest integer less than real argument
 
@@ -83,14 +83,20 @@
 ! **********************************************************************************************************************************
 ! Make sure array is sorted into numerically increasing order
 
-      DO N=2,ASIZE
-         IF (ARRAY(N) < ARRAY(N-1)) THEN
-            FATAL_ERR = FATAL_ERR + 1
-            WRITE(ERR,920) CALLING_SUBR, ARRAY_NAME
-            WRITE(F06,920) CALLING_SUBR, ARRAY_NAME
-            CALL OUTA_HERE ( 'Y' )
-         ENDIF
-      ENDDO
+!       DO N=2,ASIZE
+!          IF (ARRAY(N) < ARRAY(N-1)) THEN
+!             FATAL_ERR = FATAL_ERR + 1
+!             WRITE(ERR,920) CALLING_SUBR, ARRAY_NAME
+!             WRITE(F06,920) CALLING_SUBR, ARRAY_NAME
+!             CALL OUTA_HERE ( 'Y' )
+!          ENDIF
+!       ENDDO
+
+! Check to see if our binary search will have an integer overflow
+! Pick a more appropriate version if so, or raise an error
+     IF ((ASIZE+1) > (HUGE(TMP_N)-1)/2) THEN
+        ! use the double version I guess?
+     ENDIF
 
 ! Initialize outputs
 
@@ -100,13 +106,13 @@
 
       HI     = ASIZE
       LO     = 0
-      DBL_HI = DBLE(HI)
-      DBL_LO = DBLE(LO)
+      TMP_HI = HI
+      TMP_LO = LO
       LAST   = 0
 
       DO
-         DBL_N = (DBL_HI + DBL_LO + ONE)/TWO
-         N     = FLOOR(DBL_N)
+         N = (TMP_HI + TMP_LO + 1)/2
+      !    N     = FLOOR(DBL_N)
          IF (N == LAST) THEN
             ROW_NUM = -1
             RETURN
@@ -114,11 +120,11 @@
          LAST = N  
          IF      (EXT_ID <  ARRAY(N)) THEN
            HI     = N
-           DBL_HI = DBLE(HI)
+           TMP_HI = HI
            CYCLE
          ELSE IF (EXT_ID >  ARRAY(N)) THEN
            LO     = N
-           DBL_LO = DBLE(LO)
+           TMP_LO = LO
            CYCLE
          ELSE IF (EXT_ID == ARRAY(N)) THEN 
            EXIT

--- a/Source/UTIL/GET_ARRAY_ROW_NUM.f90
+++ b/Source/UTIL/GET_ARRAY_ROW_NUM.f90
@@ -82,7 +82,11 @@
 ! Check to see if our binary search will have an integer overflow
 ! Pick a more appropriate version if so, or raise an error
      IF ((ASIZE+1) > (HUGE(TMP_N)-1)/2) THEN
-        ! use the double version I guess?
+        ! use the double version I guess? Just error for now.
+        FATAL_ERR = FATAL_ERR + 1
+        WRITE(ERR,9003) CALLING_SUBR, ARRAY_NAME
+        WRITE(F06,9003) CALLING_SUBR, ARRAY_NAME
+        CALL OUTA_HERE ( 'Y' )
      ENDIF
 
 ! Initialize outputs
@@ -130,7 +134,8 @@
       RETURN
 
 
-
+ 9003 FORMAT(' *ERROR   9003: ERROR IN SUBROUTINE ',A                                                                   &
+      ,/,14X,' INPUT ARRAY ',A,' HAS TOO MANY ELEMENTS AND WILL OVERFLOW INTEGER(LONG) INDEX, MAX SUPPORTED ELEMS: 1073741823')
 
 
 ! **********************************************************************************************************************************

--- a/Source/UTIL/GET_ARRAY_ROW_NUM.f90
+++ b/Source/UTIL/GET_ARRAY_ROW_NUM.f90
@@ -142,7 +142,7 @@
 
       END SUBROUTINE GET_ARRAY_ROW_NUM
 
-      SUBROUTINE ASSERT_ARRAY_SORTED ( ARRAY_NAME, CALLING_SUBR, ASIZE, ARRAY, EXT_ID, ROW_NUM )
+      SUBROUTINE ASSERT_ARRAY_SORTED ( ARRAY_NAME, CALLING_SUBR, ASIZE, ARRAY )
       !     Checks and asserts that the array is sorted
       !     This check was previously internal to GET_ARRAY_ROW_NUM, however that function is usually called in large loops
       !     leading to much longer runtimes.
@@ -163,8 +163,6 @@
 
       INTEGER(LONG), INTENT(IN)       :: ASIZE             ! Size of ARRAY
       INTEGER(LONG), INTENT(IN)       :: ARRAY(ASIZE)      ! Array to search
-      INTEGER(LONG), INTENT(IN)       :: EXT_ID            ! External (actual) ID to find in ARRAY
-      INTEGER(LONG), INTENT(OUT)      :: ROW_NUM           ! Internal ID (row in ARRAY) where EXT_ID exists
       INTEGER(LONG)                   :: N                 ! Loop index
       ! **********************************************************************************************************************************
 

--- a/Source/UTIL/PARTITION_SS.f90
+++ b/Source/UTIL/PARTITION_SS.f90
@@ -251,8 +251,8 @@ i_do: DO I=1,NROW_A                                        ! Matrix partition lo
             I_B(L+1) = I_B(L)                              ! Start out with next I_B equal to last.
 
                                                            ! Write message to screen
-            CALL OURTIM
             IF (NOCOUNTS /= 'Y') THEN
+               CALL OURTIM
                WRITE(SC1,12345,ADVANCE='NO') MAT_B_NAME, MAT_A_NAME, L, NROW_B, SYM_A, SYM_B, HOUR, MINUTE, SEC, SFRAC, CR13
             ENDIF
             DO K=1,AROW_MAX_TERMS                          ! Null J_AROW and AROW each time we begin a new row of A


### PR DESCRIPTION
This PR results in a large improvement in runtime for big problems, on the order of a 20x reduction for a problem with 45k CHEXA elements and 90k GRIDS.

There are 3 main changes, first is removing the sortedness check from subr GET_ARRAY_ROW_NUM. This subr is often called in DO loops of size NELEM or NGRID, which leads to repeating the sortedness check many times. The second change is in the same subr, changing the data types used in the binary search to long integers, from real doubles.

The last change is to rewrite the sparse matrix transpose function MATTRNSP_SS. The new implementation is based on the algorithm used in scipy.sparse.

I've tested this with nastester on the benchmark deck and it appears to pass all tests, but please check my work. :)