### PR TITLE
Change PSOLID IN and ISOP options

### DIFF
--- a/Source/EMG/EMG1/ELMDAT1.f90
+++ b/Source/EMG/EMG1/ELMDAT1.f90
@@ -435,6 +435,7 @@
 
       ENDIF
 
+! **********************************************************************************************************************************
 ! Generate ISOLID array of solid element integer data (matl coord system, integration order, stress location, scheme)
 
       IF ((TYPE(1:4) == 'HEXA') .OR. (TYPE(1:5) == 'PENTA') .OR. (TYPE(1:5) == 'TETRA')) THEN
@@ -443,43 +444,104 @@
          ENDDO
       ENDIF
 
-! Check solid element integration order for validity for this element type
+! Set default integration order if IN = blank
 
-      IF (TYPE == 'HEXA8'  ) THEN
-         IF (ISOLID(4) == 0) THEN
-            ISOLID(4) = 2
-         ENDIF
-      ENDIF
+      IF (ISOLID(4) == -1) THEN
 
-      IF (TYPE == 'HEXA20' ) THEN
-         IF (ISOLID(4) == 0) THEN
+        IF (TYPE == 'HEXA8'  ) THEN
+            WRITE(ERR,1964) TYPE
+            WRITE(F06,1964) TYPE
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        ELSE IF (TYPE == 'HEXA20' ) THEN
             ISOLID(4) = 3
-         ENDIF
-      ENDIF
-
-      IF (TYPE == 'PENTA6' ) THEN
-         IF (ISOLID(4) == 0) THEN
-            ISOLID(4) = 2
-         ENDIF
-      ENDIF
-
-      IF (TYPE == 'PENTA15') THEN
-         IF (ISOLID(4) == 0) THEN
+        ELSE IF (TYPE == 'PENTA6' ) THEN
+            WRITE(ERR,1964) TYPE
+            WRITE(F06,1964) TYPE
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        ELSE IF (TYPE == 'PENTA15') THEN
             ISOLID(4) = 3
-         ENDIF
-      ENDIF
-
-      IF (TYPE == 'TETRA4' ) THEN
-         IF (ISOLID(4) == 0) THEN
+        ELSE IF (TYPE == 'TETRA4' ) THEN
             ISOLID(4) = 2
-         ENDIF
-      ENDIF
-
-      IF (TYPE == 'TETRA10') THEN
-         IF (ISOLID(4) == 0) THEN
+        ELSE IF (TYPE == 'TETRA10') THEN
             ISOLID(4) = 3
-         ENDIF
-      ENDIF
+        ELSE
+            WRITE(ERR,1967) SUBR_NAME
+            WRITE(F06,1967) SUBR_NAME
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        ENDIF
+
+      ELSE IF (ISOLID(4) == 2) THEN
+
+        IF (TYPE == 'TETRA10') THEN
+            WRITE(ERR,1965) "IN","TWO",TYPE
+            WRITE(F06,1965) "IN","TWO",TYPE
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        END IF
+
+      END IF
+
+! Set reduced/standard integration option if ISOP = blank, 0, or 1
+
+      IF (ISOLID(6) == -3) then ! -3 means ISOP = 1
+
+        IF ((TYPE == 'HEXA8'  ) .OR. (TYPE == 'HEXA20' ) .OR. (TYPE == 'PENTA6' ) .OR. (TYPE == 'PENTA15')) THEN
+          ISOLID(6) = 1
+        ELSE IF ((TYPE == 'TETRA4' ) .OR. (TYPE == 'TETRA10')) THEN
+            WRITE(ERR,1965) "ISOP","1",TYPE
+            WRITE(F06,1965) "ISOP","1",TYPE
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        ELSE
+            WRITE(ERR,1967) SUBR_NAME
+            WRITE(F06,1967) SUBR_NAME
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        ENDIF
+
+      ELSE IF (ISOLID(6) == -2) then ! -2 means ISOP = 0
+
+        IF ((TYPE == 'HEXA8'  ) .OR. (TYPE == 'HEXA20' ) .OR. (TYPE == 'PENTA6' ) .OR. (TYPE == 'PENTA15')) THEN
+          ISOLID(6) = 0
+        ELSE IF ((TYPE == 'TETRA4' ) .OR. (TYPE == 'TETRA10')) THEN
+            WRITE(ERR,1965) "ISOP","0",TYPE
+            WRITE(F06,1965) "ISOP","0",TYPE
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        ELSE
+            WRITE(ERR,1967) SUBR_NAME
+            WRITE(F06,1967) SUBR_NAME
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        ENDIF
+
+      ELSE IF (ISOLID(6) == -1) then ! -1 means ISOP = blank
+
+        IF ((TYPE == 'HEXA8'  ) .OR. (TYPE == 'HEXA20' ) .OR. (TYPE == 'PENTA6' ) .OR. (TYPE == 'PENTA15')) THEN
+          ISOLID(6) = 0
+        ELSE IF ((TYPE == 'TETRA4' ) .OR. (TYPE == 'TETRA10')) THEN
+          ISOLID(6) = 1
+        ELSE
+            WRITE(ERR,1967) SUBR_NAME
+            WRITE(F06,1967) SUBR_NAME
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        ENDIF
+
+      ELSE IF (ISOLID(6) == 0) then ! 0 means ISOP = REDUCED
+
+        IF ((TYPE == 'TETRA4' ) .OR. (TYPE == 'TETRA10')) THEN
+            WRITE(ERR,1965) "ISOP","REDUCED",TYPE
+            WRITE(F06,1965) "ISOP","REDUCED",TYPE
+            NUM_EMG_FATAL_ERRS = NUM_EMG_FATAL_ERRS + 1
+            FATAL_ERR = FATAL_ERR + 1
+        ENDIF
+
+      END IF
+
 
 ! **********************************************************************************************************************************
 ! Generate EMAT matl props for this elem.  Shell elems with PCOMP_PROPS are handled in subr SHELL_ABD_MATRICES.
@@ -951,7 +1013,11 @@
  1960 FORMAT(' *ERROR  1960: ',A,I8,' MUST HAVE A CID COORD SYSTEM (FIELD 9 OF CBUSH BULK DATA ENTRY) DEFINED WHEN THE 2 GRIDS ARE'&
                                    ,' COINCIDENT. HOWEVER, CID = ',I8)
 
+ 1964 FORMAT(' *ERROR  1964: PSOLID ENTRY HAD FIELD FOR IN BLANK WITH ELEMENT TYPE ',A)
 
+ 1965 FORMAT(' *ERROR  1965: PSOLID ENTRY HAD FIELD FOR ',A,' = "',A,'" WITH ELEMENT TYPE ',A)
+
+ 1967 FORMAT(' *ERROR  1967: PROGRAMMING ERROR IN SUBROUTINE ',A)
 
 
 

--- a/Source/LK1/L1A-BD/BD_PSOLID.f90
+++ b/Source/LK1/L1A-BD/BD_PSOLID.f90
@@ -131,8 +131,8 @@
       PSOLID(NPSOLID,4) = 0                                ! Read integration order and enter into array PSOLID
       CHR_FLD = JCARD(5)
       CALL LEFT_ADJ_BDFLD ( CHR_FLD )
-      IF       (CHR_FLD(1:) == ' ') THEN                   ! Don't allow actual 0
-         PSOLID(NPSOLID,4) = 0                             ! Temporarily set  int order to 0. Subr ELMDAT1 will change this
+      IF       (CHR_FLD(1:) == ' ') THEN
+         PSOLID(NPSOLID,4) = -1                            ! Temporary value that will be changed in ELMDAT1
       ELSE IF ((CHR_FLD(1:8) == 'TWO     ') .OR. (CHR_FLD(1:8) == '2       ')) THEN
          PSOLID(NPSOLID,4) = 2
       ELSE IF ((CHR_FLD(1:8) == 'THREE   ') .OR. (CHR_FLD(1:8) == '3       ')) THEN
@@ -149,9 +149,15 @@
       PSOLID(NPSOLID,6) = 0                                ! Read integration scheme and enter into array PSOLID
       CHR_FLD = JCARD(7)
       CALL LEFT_ADJ_BDFLD ( CHR_FLD )
-      IF      ((CHR_FLD(1:8) == 'REDUCED ') .OR. (CHR_FLD(1:8) == '        ') .OR. (CHR_FLD(1:8) == '0       ')) THEN
+      IF      (CHR_FLD(1:8) == '1       ') THEN
+         ID = -3                                           ! Temporary value that will be changed in ELMDAT1
+      ELSE IF (CHR_FLD(1:8) == '0       ') THEN
+         ID = -2                                           ! Temporary value that will be changed in ELMDAT1
+      ELSE IF (CHR_FLD(1:8) == '        ') THEN
+         ID = -1                                           ! Temporary value that will be changed in ELMDAT1
+      ELSE IF (CHR_FLD(1:8) == 'REDUCED ') THEN
          ID = 0
-      ELSE IF ((CHR_FLD(1:8) == 'FULL    ') .OR. (CHR_FLD(1:8) == '1       ')) THEN
+      ELSE IF (CHR_FLD(1:8) == 'FULL    ') THEN
          ID = 1
       ELSE
          FATAL_ERR = FATAL_ERR + 1
@@ -159,21 +165,6 @@
          WRITE(F06,1104) JCARD(7),JF(7),JCARD(1),JCARD(2)
       ENDIF
       PSOLID(NPSOLID,6) = ID
-
-! Make sure that the entries for integrtion order and scheme make sense
-
-      IF ((PSOLID(NPSOLID,4) == 0) .AND. (PSOLID(NPSOLID,6) /= 0)) THEN
-         PSOLID(NPSOLID,6) = 0
-         WARN_ERR = WARN_ERR + 1
-         WRITE(ERR,101) CARD
-         WRITE(ERR,1107) JCARD(2)
-         IF (SUPWARN == 'N') THEN
-            IF (ECHO == 'NONE  ') THEN
-               WRITE(F06,101) CARD
-            ENDIF
-            WRITE(F06,1107) JCARD(2)
-         ENDIF
-      ENDIF
 
       CALL BD_IMBEDDED_BLANK ( JCARD,2,3,4,5,0,7,0,0 )     ! Make sure that there are no imbedded blanks in fields 2-5,7
       CALL CARD_FLDS_NOT_BLANK ( JCARD,0,0,0,0,6,0,8,9 )   ! Issue warning if fields 6, 8 and 9 not blank
@@ -192,8 +183,6 @@
   101 FORMAT(A)
 
  1104 FORMAT(' *ERROR  1104: INVALID ENTRY = "',A,'" IN FIELD ',I3,' OF ',A,' ENTRY WITH ID = ',A)
-
- 1107 FORMAT(' *WARNING    : DATA IN FIELDS 5 AND 7 OF PSOLID ENTRY WITH ID = ',A,' ARE INCONSISTENT. DEFAULTS WILL BE USED')
 
  1145 FORMAT(' *ERROR  1145: DUPLICATE ',A,' ENTRY WITH ID = ',I8)
  


### PR DESCRIPTION
Changed the allowed values of those parameters to:

![image](https://github.com/user-attachments/assets/4293d32b-a877-4faa-b19e-209566056ed4)

Bold underline are default values if field is blank.

Changes include:
- Disallowing any default value for IN on CHEXA 8 and CPENTA 6 because Mystran doesn’t have bubble functions.
- Removing 1-point integration (IN=2) for CTETRA 10.
- Removing the confusing way that ISOP=FULL really means REDUCED shear integrations if IN=blank.
- Disallowing ISOP=0 or 1 for TETRA.

This makes it more consistent with MSC and Simcenter Nastrans.









