### PR TITLE
Changed ALPVEC use for solid, membrane, composite

### DIFF
--- a/Source/EMG/EMG1/ROT_COMP_ELEM_AXES.f90
+++ b/Source/EMG/EMG1/ROT_COMP_ELEM_AXES.f90
@@ -257,10 +257,10 @@
             ENDDO
          ENDDO
 
-         DO I=1,3                                          ! Transform ALPVEC rows for ply membrane from ply to elem axes
-            DO J=1,MEMATC
-               ALP3(I,J) = ALPVEC(I,J)
-            ENDDO
+         DO J=1,MEMATC                                     ! Transform ALPVEC rows for ply membrane from ply to elem axes
+            ALP3(1,J) = ALPVEC(1,J)
+            ALP3(2,J) = ALPVEC(2,J)
+            ALP3(3,J) = ALPVEC(4,J)
          ENDDO
 
          CALL MATMULT_FFF ( T1M   , EM  , 3, 3, 3, DUM33 ) ! (1) Transform EM  membrane matl matrix from ply to elem coords
@@ -277,15 +277,13 @@
 
          CALL MATMULT_FFF_T ( T2M, ALP3, 3, 3, MEMATC, DUM3M )
 
-         DO I=1,6
-            DO J=1,MEMATC
-               ALPVEC(I,J) = ZERO
-            ENDDO
-         ENDDO
-         DO I=1,3
-            DO J=1,MEMATC
-               ALPVEC(I,J) = DUM3M(I,J)
-            ENDDO
+         DO J=1,MEMATC
+            ALPVEC(1,J) = DUM3M(1,J)
+            ALPVEC(2,J) = DUM3M(2,J)
+            ALPVEC(3,J) = ZERO
+            ALPVEC(4,J) = DUM3M(3,J)
+            ALPVEC(5,J) = ZERO
+            ALPVEC(6,J) = ZERO
          ENDDO
 
 

--- a/Source/EMG/EMG1/SHELL_ABD_MATRICES.f90
+++ b/Source/EMG/EMG1/SHELL_ABD_MATRICES.f90
@@ -191,7 +191,7 @@ pcom0:IF (PCOMP_PROPS == 'N') THEN                         ! Element is not a co
 
          ALPM(1) = ALPVEC(1,1)                             ! xx
          ALPM(2) = ALPVEC(2,1)                             ! yy
-         ALPM(3) = ALPVEC(4,1)*2                           ! xy
+         ALPM(3) = ALPVEC(4,1)                             ! xy
  
          CALL MATMULT_FFF ( EB, ALPB, 3, 3, 1, DUM )
          DO I=1,3
@@ -432,8 +432,11 @@ ply_do:  DO K=1,NUM_PLIES_TO_PROC
                ENDDO
             ENDDO
 
+            ALPM(1) = ALPVEC(1,1)
+            ALPM(2) = ALPVEC(2,1)
+            ALPM(3) = ALPVEC(4,1)
+
             DO I=1,3
-               ALPM(I) = ALPVEC(I,1)
                ALPD(I) = ALPVEC(I,2)
                ALPB(I) = ALPVEC(I,4)
             ENDDO

--- a/Source/EMG/EMG4/QMEM1.f90
+++ b/Source/EMG/EMG4/QMEM1.f90
@@ -252,9 +252,6 @@
 ! code uses EM and ALPVEC rather than SHELL_AALP
  
       IF (OPT(3) == 'Y') THEN
-         ALP(1) = ALPVEC(1,1)
-         ALP(2) = ALPVEC(2,1)
-         ALP(3) = ALPVEC(3,1)
 
          IORD_MSG = 'for in-plane direct strains                 = '
          GAUSS_PT = 1
@@ -280,7 +277,7 @@
 
          ALP(1) = ALPVEC(1,1)
          ALP(2) = ALPVEC(2,1)
-         ALP(3) = ALPVEC(3,1)
+         ALP(3) = ALPVEC(4,1)
 
          CALL MATMULT_FFF ( EM, ALP, 3, 3, 1, EALP )
          DO J=1,NTSUB

--- a/Source/EMG/EMG4/TMEM1.f90
+++ b/Source/EMG/EMG4/TMEM1.f90
@@ -213,7 +213,7 @@
 
          ALP(1) = ALPVEC(1,1)
          ALP(2) = ALPVEC(2,1)
-         ALP(3) = ALPVEC(3,1)
+         ALP(3) = ALPVEC(4,1)
 
          CALL MATMULT_FFF ( EM, ALP, 3, 3, 1, EALP )
          DO J=1,NTSUB

--- a/Source/EMG/EMG5/HEXA.f90
+++ b/Source/EMG/EMG5/HEXA.f90
@@ -170,13 +170,9 @@
       ENDDO
 
 ! ALP is first col of ALPVEC
-
-      ALP(1) = ALPVEC(1,1)
-      ALP(2) = ALPVEC(2,1)
-      ALP(3) = ALPVEC(3,1)
-      ALP(4) = ALPVEC(4,1) * 2
-      ALP(5) = ALPVEC(5,1) * 2
-      ALP(6) = ALPVEC(6,1) * 2
+      DO I=1,6
+        ALP(I) = ALPVEC(I,1)
+      ENDDO
 
       TREF1 = TREF(1)
 

--- a/Source/EMG/EMG5/PENTA.f90
+++ b/Source/EMG/EMG5/PENTA.f90
@@ -178,13 +178,9 @@
       ENDDO
 
 ! ALP is first col of ALPVEC
-
-      ALP(1) = ALPVEC(1,1)
-      ALP(2) = ALPVEC(2,1)
-      ALP(3) = ALPVEC(3,1)
-      ALP(4) = ALPVEC(4,1) * 2
-      ALP(5) = ALPVEC(5,1) * 2
-      ALP(6) = ALPVEC(6,1) * 2
+      DO I=1,6
+        ALP(I) = ALPVEC(I,1)
+      ENDDO
     
       TREF1 = TREF(1)
  

--- a/Source/EMG/EMG5/TETRA.f90
+++ b/Source/EMG/EMG5/TETRA.f90
@@ -163,13 +163,9 @@
       ENDDO
 
 ! ALP is first col of ALPVEC
-
-      ALP(1) = ALPVEC(1,1)
-      ALP(2) = ALPVEC(2,1)
-      ALP(3) = ALPVEC(3,1)
-      ALP(4) = ALPVEC(4,1) * 2
-      ALP(5) = ALPVEC(5,1) * 2
-      ALP(6) = ALPVEC(6,1) * 2
+      DO I=1,6
+        ALP(I) = ALPVEC(I,1)
+      ENDDO
     
       TREF1 = TREF(1)
  

--- a/Source/EMG/EMG8/ROT_AXES_MATL_TO_LOC.f90
+++ b/Source/EMG/EMG8/ROT_AXES_MATL_TO_LOC.f90
@@ -32,7 +32,7 @@
       USE IOUNT1, ONLY                :  WRT_LOG, ERR, F04, F06
       USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR, MEMATC, NCORD
       USE TIMDAT, ONLY                :  TSEC
-      USE CONSTANTS_1, ONLY           :  ZERO, ONE
+      USE CONSTANTS_1, ONLY           :  ZERO, ONE, TWO
       USE MODEL_STUF, ONLY            :  ALPVEC, CORD, ISOLID, EB, EBM, EM, ES, ET, MTRL_TYPE, NUM_EMG_FATAL_ERRS, QUAD_DELTA,     &
                                          RCORD, TE, THETAM, TYPE
       USE PARAMS, ONLY                :  EPSIL
@@ -171,10 +171,20 @@
                CALL MATMULT_FFF_T ( T1_MB, DUM33, 3, 3, 3, EBM   )
             ENDIF
 
+            DO I=4,6
+               DO J=1,MEMATC
+                  ALPVEC(I,J) = ALPVEC(I,J) / TWO                    ! Remove shear factor of 2 to transform.
+               ENDDO
+            ENDDO
             CALL MATMULT_FFF_T (T1, ALPVEC, 6, 6, MEMATC, DUM64 )    ! Transform CTE matrix
             DO I=1,6
                DO J=1,MEMATC
                   ALPVEC(I,J) = DUM64(I,J)
+               ENDDO
+            ENDDO
+            DO I=4,6
+               DO J=1,MEMATC
+                  ALPVEC(I,J) = ALPVEC(I,J) * TWO                     ! Reinstate shear factor of 2 after transform.
                ENDDO
             ENDDO
 
@@ -258,11 +268,20 @@
             CALL MATMULT_FFF   ( ES , T1   , 6, 6, 6, DUM66 )
             CALL MATMULT_FFF_T ( T1 , DUM66, 6, 6, 6, ES    )
 
-            CALL MATMULT_FFF_T (T1, ALPVEC, 6, 6, MEMATC, DUM64 )
-
+            DO I=4,6
+               DO J=1,MEMATC
+                  ALPVEC(I,J) = ALPVEC(I,J) / TWO                    ! Remove shear factor of 2 to transform.
+               ENDDO
+            ENDDO
+            CALL MATMULT_FFF_T (T1, ALPVEC, 6, 6, MEMATC, DUM64 )    ! Transform CTE matrix
             DO I=1,6
                DO J=1,MEMATC
                   ALPVEC(I,J) = DUM64(I,J)
+               ENDDO
+            ENDDO
+            DO I=4,6
+               DO J=1,MEMATC
+                  ALPVEC(I,J) = ALPVEC(I,J) * TWO                     ! Reinstate shear factor of 2 after transform.
                ENDDO
             ENDDO
 

--- a/Source/LK9/L92/ELEM_STRE_STRN_ARRAYS.f90
+++ b/Source/LK9/L92/ELEM_STRE_STRN_ARRAYS.f90
@@ -201,22 +201,26 @@
             STRAIN3(I) = STRAIN(I+6)
          ENDDO
 
-         DO I=1,3
-            IF (SUBLOD(INT_SC_NUM,2) > 0) THEN
-               TBAR = 0
-               DO J=1,ELGP
-                 TBAR = TBAR + DT(J,JTSUB)
-               ENDDO
-               TBAR = TBAR / ELGP
-               ALPTM(I) = ALPVEC(I  ,1)*(TBAR - TREF(1))
-               ALPTB(I) = ALPVEC(I  ,2)*DT(5,JTSUB)
-               ALPTT(I) = ALPVEC(I+3,3)*(TBAR - TREF(1))
-            ELSE
-               ALPTM(I) = ZERO
-               ALPTB(I) = ZERO
-               ALPTT(I) = ZERO
-            ENDIF
-         ENDDO
+         IF (SUBLOD(INT_SC_NUM,2) > 0) THEN
+           TBAR = 0
+           DO J=1,ELGP
+             TBAR = TBAR + DT(J,JTSUB)
+           ENDDO
+           TBAR = TBAR / ELGP
+           ALPTM(1) = ALPVEC(1  ,1)*(TBAR - TREF(1))
+           ALPTM(2) = ALPVEC(2  ,1)*(TBAR - TREF(1))
+           ALPTM(3) = ALPVEC(4  ,1)*(TBAR - TREF(1))
+           DO I=1,3
+             ALPTB(I) = ALPVEC(I  ,2)*DT(5,JTSUB)
+             ALPTT(I) = ALPVEC(I+3,3)*(TBAR - TREF(1))
+           ENDDO
+         ELSE
+           DO I=1,3
+             ALPTM(I) = ZERO
+             ALPTB(I) = ZERO
+             ALPTT(I) = ZERO
+           ENDDO
+         ENDIF
       
 
          DO I=1,3

--- a/Source/Modules/MODEL_STUF.f90
+++ b/Source/Modules/MODEL_STUF.f90
@@ -1352,7 +1352,13 @@
                                                              ! The ply number in a composite layup defined by a PCOMP
 
       REAL(DOUBLE)                    :: ALPVEC(6,MEMATC)    = RESHAPE ( (/(ZERO, I=1,6*MEMATC)/), (/6,MEMATC/) )
-                                                             ! Vector of CTE's.
+                                                             ! Vector of CTE's. x,y,z,xy,yz,zx in material coordinates.
+                                                             ! For shells, column i is for material MIDi. i=1..4.
+                                                             ! For solids, only the column 1 is used.
+                                                             ! They are engineering strain per unit temperature change
+                                                             ! rather than tensor components so the shear components 
+                                                             ! must be divided by 2 before transforming and used as-is
+                                                             ! for multiplying by elasticity.
 
       REAL(DOUBLE)                    :: BENSUM              = ZERO   
                                                              ! Sum of diag stiffness from KB for rotation DOF's


### PR DESCRIPTION
Fixes issue https://github.com/MYSTRANsolver/MYSTRAN/issues/136 

Also reorganizes the shear factor of 2 to be located right next to the transformations.