### PR TITLE
included -1/t^2 factor in MID4 output

### DIFF
--- a/Source/EMG/EMG1/WRITE_PCOMP_EQUIV.f90
+++ b/Source/EMG/EMG1/WRITE_PCOMP_EQUIV.f90
@@ -133,7 +133,7 @@
       DO I=1,3
          DO J =1,3
             PCOMP_MEM_MAT2(I,J) = SHELL_A(I,J)/PCOMP_TM
-            PCOMP_MBC_MAT2(I,J) = SHELL_B(I,J)
+            PCOMP_MBC_MAT2(I,J) = SHELL_B(I,J)/-(PCOMP_TM * PCOMP_TM)
             PCOMP_BEN_MAT2(I,J) = SHELL_D(I,J)/PCOMP_IB
          ENDDO
       ENDDO
@@ -210,7 +210,6 @@
       IF (IERR(4) == 0) THEN
          WRITE(F06,9912) PCOMP(INTL_PID,1), MID1_PCOMP_EQ, C8FLD_TM, MID2_PCOMP_EQ, MID3_PCOMP_EQ,ICONT,                           &
                          ICONT, C8FLD_ZS(2), C8FLD_ZS(2), MID4_PCOMP_EQ
-
       ELSE
          WRITE(F06,9913) PCOMP(INTL_PID,1), MID1_PCOMP_EQ, C8FLD_TM, MID2_PCOMP_EQ, MID3_PCOMP_EQ,ICONT,                           &
                             ICONT, C8FLD_ZS(1), C8FLD_ZS(2)


### PR DESCRIPTION
Fix for issue #152

Matches MSC and is how you'd expect it to be.


Example from Mystran with this PR:
```
MAT2     ,  4000001, 1.1845+6, -1.815+5, 5.0146+5, -8.213+5, 5.0146+5, -1.815+5, 0.0000+0, +1000005
 +1000005,        ,        ,        , 0.0000+0

```

and the same PCOMP from MSC:
```
  MAT2       400000001  1.1845E+06 -1.8155E+05  5.0146E+05 -8.2137E+05  5.0146E+05 -1.8155E+05  0.0000E+00
            0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00
                     0  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00  0.0000E+00

```