### PR TITLE
Getting rid of fort.N files and the many issues they cause

### DIFF
--- a/Source/LK9/L91/WRITE_BAR.f90
+++ b/Source/LK9/L91/WRITE_BAR.f90
@@ -1,33 +1,33 @@
 ! ##################################################################################################################################
-! Begin MIT license text.                                                                                    
+! Begin MIT license text.
 ! _______________________________________________________________________________________________________
-                                                                                                         
-! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)                                              
-                                                                                                         
-! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and      
+
+! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 ! associated documentation files (the "Software"), to deal in the Software without restriction, including
 ! without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to   
-! the following conditions:                                                                              
-                                                                                                         
-! The above copyright notice and this permission notice shall be included in all copies or substantial   
-! portions of the Software and documentation.                                                                              
-                                                                                                         
-! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS                                
-! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                            
-! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                            
-! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                                 
-! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                          
-! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                              
-! THE SOFTWARE.                                                                                          
+! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to
+! the following conditions:
+
+! The above copyright notice and this permission notice shall be included in all copies or substantial
+! portions of the Software and documentation.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
 ! _______________________________________________________________________________________________________
-                                                                                                        
-! End MIT license text.                                                                                      
- 
+
+! End MIT license text.
+
       SUBROUTINE WRITE_BAR (NUM, FILL_F06, FILL_ANS, ISUBCASE, ITABLE,  &
                             TITLE, SUBTITLE, LABEL,                     &
                             FIELD5_INT_MODE, FIELD6_EIGENVALUE )
- 
+
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ANS, ERR, F04, F06, OP2
       USE SCONTR, ONLY                :  BARTOR, BLNK_SUB_NAM, MOGEL
@@ -37,11 +37,11 @@
       USE DEBUG_PARAMETERS, ONLY      :  DEBUG
       USE LINK9_STUFF, ONLY           :  EID_OUT_ARRAY, MAXREQ, MSPRNT, OGEL
       USE PARAMS, ONLY                :  PRTANS
- 
+
       USE WRITE_BAR_USE_IFs
 
       IMPLICIT NONE
- 
+
       CHARACTER(LEN=LEN(BLNK_SUB_NAM)):: SUBR_NAME = 'WRITE_BAR'
 
       CHARACTER(LEN=*), INTENT(IN)    :: FILL_F06          ! Padding for output format
@@ -54,7 +54,7 @@
       REAL(DOUBLE),  INTENT(IN)       :: FIELD6_EIGENVALUE
 
       CHARACTER(133*BYTE)             :: BLINE1A           ! Result of concatenating char. variables BOUT1, BMS1, BMSF1, BTOR to
-!                                                            make the 1st line of stress output for a CBAR with torsional stress 
+!                                                            make the 1st line of stress output for a CBAR with torsional stress
       CHARACTER(133*BYTE)             :: BLINE1B           ! Result of concatenating char. variables BOUT1, BMS1, BMSF1, BMS2, BMSF2
 !                                                            to make the 1st line of stress output for a CBAR w/o torsional stress
       CHARACTER(133*BYTE)             :: BLINE2A           ! Result of concatenating char. variables BOUT2, BMS2, BMSF2
@@ -76,13 +76,13 @@
       CHARACTER(14*BYTE)              :: MIN_ANS_CHAR(16)  ! Character variable that contains the 6 grid min  outputs
       CHARACTER(  1*BYTE)             :: MSFLAG            ! If margin is negative, MSFLAG is an *
       CHARACTER(14*BYTE)              :: OGEL_CHAR(MOGEL)  ! Char representation of 1 row of OGEL outputs
- 
+
       INTEGER(LONG), INTENT(IN)       :: ISUBCASE          ! The subcase ID
       INTEGER(LONG), INTENT(IN)       :: NUM               ! The number of rows of OGEL to write out
       INTEGER(LONG)                   :: I,J               ! DO loop indices
       INTEGER(LONG)                   :: K                 ! Counter
       INTEGER(LONG), PARAMETER        :: SUBR_BEGEND = WRITE_BAR_BEGEND
- 
+
       REAL(DOUBLE)                    :: ABS_ANS(16)       ! Max ABS for all grids output for each of the 6 disp components
       REAL(DOUBLE)                    :: MAX_ANS(16)       ! Max for all grids output for each of the 6 disp components
       REAL(DOUBLE)                    :: MIN_ANS(16)       ! Min for all grids output for each of the 6 disp components
@@ -106,9 +106,9 @@
       ! Data is first written to character variables and then that character variable is output the F06 and ANS.
       ! op2_headers = ['s1a', 's2a', 's3a', 's4a', 'axial', 'smaxa', 'smina', 'MS_tension',
       !                's1b', 's2b', 's3b', 's4b',          'smaxb', 'sminb', 'MS_compression']
- 
+
       NVALUES = NUM_WIDE * NUM
-      
+
       !CALL GET_STRESS_CODE(STRESS_CODE, IS_VON_MISES, IS_STRAIN, IS_FIBER_DISTANCE)
       CALL GET_STRESS_CODE( STRESS_CODE, 1,            0,         0)
       CALL WRITE_OES3_STATIC(ITABLE, ISUBCASE, DEVICE_CODE, ELEMENT_TYPE, NUM_WIDE, STRESS_CODE, &
@@ -132,14 +132,14 @@
 
          BOUT1(1:)   = ' '
          BMS1(1:)    = ' '
-         BMSF1       = ' '   
- 
+         BMSF1       = ' '
+
          BOUT2(1:)   = ' '
          BMS2(1:)    = ' '
          BMSF2       = ' '
 
-         BTOR(1:)    = ' '   
- 
+         BTOR(1:)    = ' '
+
          ! Write first line of output for one element to a temporary internal file
          K = K + 1
          CALL WRT_REAL_TO_CHAR_VAR ( OGEL, MAXREQ, MOGEL, K, OGEL_CHAR )
@@ -191,7 +191,7 @@
 
          ! Write the two lines of stress output for one element to F06
          WRITE(F06,*)
-         WRITE(ANS,*)
+         IF (PRTANS == 'Y') WRITE(ANS,*)
          IF (BARTOR == 'Y') THEN
             BLINE1A = BOUT1//BMS1//BMSF1//BTOR
             BLINE2A = BOUT2//BMS2//BMSF2//BMS3//BMSF3
@@ -283,11 +283,11 @@
              1X,'ABS (for output set):  ',7(1ES14.6),ES14.2)
 
 ! **********************************************************************************************************************************
- 
+
 ! ##################################################################################################################################
- 
+
       CONTAINS
- 
+
 ! ##################################################################################################################################
 
       SUBROUTINE GET_MAX_MIN_ABS ( BEG_COL, END_COL )
@@ -307,7 +307,7 @@
 
       DO JJ=1,2*(END_COL-BEG_COL+1)
          MAX_ANS(JJ) = -MACH_LARGE_NUM
-      ENDDO 
+      ENDDO
 
       LL = 0
       DO II=1,NUM

--- a/Source/LK9/L91/WRITE_ELEM_STRAINS.f90
+++ b/Source/LK9/L91/WRITE_ELEM_STRAINS.f90
@@ -1,34 +1,34 @@
 ! ##################################################################################################################################
-! Begin MIT license text.                                                                                    
+! Begin MIT license text.
 ! _______________________________________________________________________________________________________
-                                                                                                         
-! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)                                              
-                                                                                                         
-! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and      
+
+! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 ! associated documentation files (the "Software"), to deal in the Software without restriction, including
 ! without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to   
-! the following conditions:                                                                              
-                                                                                                         
-! The above copyright notice and this permission notice shall be included in all copies or substantial   
-! portions of the Software and documentation.                                                                              
-                                                                                                         
-! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS                                
-! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                            
-! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                            
-! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                                 
-! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                          
-! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                              
-! THE SOFTWARE.                                                                                          
+! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to
+! the following conditions:
+
+! The above copyright notice and this permission notice shall be included in all copies or substantial
+! portions of the Software and documentation.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
 ! _______________________________________________________________________________________________________
-                                                                                                        
-! End MIT license text.                                                                                      
-  
+
+! End MIT license text.
+
       SUBROUTINE WRITE_ELEM_STRAINS ( JSUB, NUM, IHDR, NUM_PTS, ITABLE )
-  
+
 ! Writes blocks of element strains for one subcase and one element type for elements that do not have PCOMP properties, including
 ! all 2-D, 3-D  plus several 1-D elements (i.e. that have strain calculations).
- 
+
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ANS, ERR, F04, F06, OP2
       USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR, BARTOR, INT_SC_NUM, MAX_NUM_STR, NDOFR, NUM_CB_DOFS,             &
@@ -42,11 +42,11 @@
       USE LINK9_STUFF, ONLY           :  EID_OUT_ARRAY, GID_OUT_ARRAY, OGEL, POLY_FIT_ERR, POLY_FIT_ERR_INDEX
       USE MODEL_STUF, ONLY            :  ELEM_ONAME, ELMTYP, LABEL, SCNUM, STITLE, TITLE, TYPE
       USE CC_OUTPUT_DESCRIBERS, ONLY  :  STRN_LOC, STRN_OPT, STRN_OUT
-  
+
       USE WRITE_ELEM_STRAINS_USE_IFs
 
       IMPLICIT NONE
- 
+
       CHARACTER(LEN=LEN(BLNK_SUB_NAM)):: SUBR_NAME = 'WRITE_ELEM_STRAINS'
       CHARACTER(LEN=*), INTENT(IN)    :: IHDR              ! Indicator of whether to write an output header
 
@@ -58,7 +58,7 @@
 
                                                            ! Indicators of whether to write note on indices of POLY_FIT_ERR
       CHARACTER( 1*BYTE)              :: WRT_ERR_INDEX_NOTE(MAX_NUM_STR)
-  
+
       INTEGER(LONG), INTENT(IN)       :: JSUB              ! Solution vector number
       INTEGER(LONG), INTENT(IN)       :: NUM               ! The number of rows of OGEL to write out
       INTEGER(LONG), INTENT(IN)       :: NUM_PTS           ! Num diff strain points for one element (3rd dim in arrays SEi, STEi)
@@ -70,11 +70,11 @@
       INTEGER(LONG)                   :: K                 ! Counter
       INTEGER(LONG)                   :: NCOLS             ! Num of cols to write out
       INTEGER(LONG), PARAMETER        :: SUBR_BEGEND = WRITE_ELEM_STRAINS_BEGEND
-  
+
       REAL(DOUBLE)                    :: ABS_ANS(11)       ! Max ABS for all element output
       REAL(DOUBLE)                    :: MAX_ANS(11)       ! Max for all element output
       REAL(DOUBLE)                    :: MIN_ANS(11)       ! Min for all element output
-      
+
       ! op2 info
       CHARACTER( 8*BYTE)              :: TABLE_NAME             ! the name of the op2 table
       INTEGER(LONG)                   :: NNODES                 ! number of nodes for the element
@@ -190,7 +190,7 @@
 
          ELSE IF (SOL_NAME(1:12) == 'GEN CB MODEL') THEN
             ISUBCASE_INDEX = 1  ! modes
-            IF ((JSUB <= NDOFR) .OR. (JSUB >= NDOFR+NVEC)) THEN 
+            IF ((JSUB <= NDOFR) .OR. (JSUB >= NDOFR+NVEC)) THEN
                IF (JSUB <= NDOFR) THEN
                   BDY_DOF_NUM = JSUB
                ELSE
@@ -402,7 +402,7 @@
 
              NUM_WIDE = 2 ! eid, spring_strain
              NVALUES = NUM_WIDE * NUM
-             
+
              DEVICE_CODE = 1   ! PLOT
 
              !CALL GET_STRESS_CODE(STRESS_CODE, IS_VON_MISES, IS_STRAIN, IS_FIBER_DISTANCE)
@@ -524,7 +524,7 @@
            CALL GET_STRESS_CODE( STRESS_CODE, 1,            1,         1)
             IF ((STRN_LOC == 'CENTER  ') .AND. (TYPE(1:5) /= 'QUAD8')) THEN
                ! CQUAD4-33
-               !(eid_device, 
+               !(eid_device,
                ! fd1, sx1, sy1, txy1, angle1, major1, minor1, vm1,
                ! fd2, sx2, sy2, txy2, angle2, major2, minor2, vm2,) = out; n=17
                NUM_WIDE = 17
@@ -543,7 +543,7 @@
                WRITE(ERR,3) NUM,NUM_PTS,STRN_LOC,ITABLE
                ELEMENT_TYPE = 144
                NUM_WIDE = 87 ! 2 + 17 * (4+1)  ! 4 nodes + 1 centroid
-               
+
                ! TODO: probably wrong...divide NUM by NUM_PTS?
                NELEMENTS = NUM / NUM_PTS
                NVALUES = NUM_WIDE * NELEMENTS
@@ -581,7 +581,7 @@
                 K = K + 1
                 WRITE(ERR,4) I,K
             WRITE(F06,*)
-            WRITE(F06,1403) FILL(1: 0), EID_OUT_ARRAY(I,1),(OGEL(K,J),J=1,10)                                                      
+            WRITE(F06,1403) FILL(1: 0), EID_OUT_ARRAY(I,1),(OGEL(K,J),J=1,10)
 
                 IF (WRITE_ANS) THEN
                     WRITE(ANS,*)
@@ -641,7 +641,7 @@
              ! Get abs POLY_FIT_ERR
              ABS_ANS(11) = MAX( DABS(MAX_ANS(11)), DABS(MIN_ANS(11)) )
 
-               IF ((STRN_LOC == 'CORNER  ') .OR. (TYPE(1:5) == 'QUAD8')) THEN 
+               IF ((STRN_LOC == 'CORNER  ') .OR. (TYPE(1:5) == 'QUAD8')) THEN
                 WRITE(F06,1408) FILL(1: 0), FILL(1: 0), MAX_ANS(2),MAX_ANS(3),MAX_ANS(4),MAX_ANS(6),MAX_ANS(7),MAX_ANS(8), &
                                             MAX_ANS(9), MAX_ANS(10),MAX_ANS(11),                                           &
                                             FILL(1: 0), MIN_ANS(2),MIN_ANS(3),MIN_ANS(4),MIN_ANS(6),MIN_ANS(7),MIN_ANS(8), &
@@ -658,7 +658,7 @@
                ENDIF
 
              IF (WRITE_ANS) THEN
-               IF ((STRN_LOC == 'CORNER  ') .OR. (TYPE(1:5) == 'QUAD8')) THEN 
+               IF ((STRN_LOC == 'CORNER  ') .OR. (TYPE(1:5) == 'QUAD8')) THEN
                  WRITE(ANS,1418)MAX_ANS(2),MAX_ANS(3),MAX_ANS(4),MAX_ANS(6),MAX_ANS(7),MAX_ANS(8),MAX_ANS(9), &
                                 MAX_ANS(10),MAX_ANS(11),                                                      &
                                 MIN_ANS(2),MIN_ANS(3),MIN_ANS(4),MIN_ANS(6),MIN_ANS(7),MIN_ANS(8),MIN_ANS(9), &
@@ -713,7 +713,7 @@
              !CALL GET_STRESS_CODE(STRESS_CODE, IS_VON_MISES, IS_STRAIN, IS_FIBER_DISTANCE)
              CALL GET_STRESS_CODE( STRESS_CODE, 0,            1,         0)
              NVALUES = NUM * NUM_WIDE
-             
+
              CALL WRITE_OES3_STATIC(ITABLE, ISUBCASE, DEVICE_CODE, ELEMENT_TYPE, NUM_WIDE, STRESS_CODE, &
                                     TITLEI, STITLEI, LABELI, FIELD5_INT_MODE, FIELD6_EIGENVALUE)
 
@@ -760,12 +760,12 @@
   201 FORMAT(1X,A)
 
   301 FORMAT(1X,A,'E L E M E N T   S T R A I N S   I N   L O C A L   E L E M E N T   C O O R D I N A T E   S Y S T E M')
-  
+
   302 FORMAT(1X,A,'C B   E L E M E N T   S T R A I N S   O T M   I N   L O C A L   E L E M E N T   C O O R D I N A T E',           &
   '   S Y S T E M')
-  
+
   401 FORMAT(A,'F O R   E L E M E N T   T Y P E   ',A11)
- 
+
 
 
 ! BAR >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -782,7 +782,7 @@
 ! ELAS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  1201 FORMAT(1X,A,'Element     Strain     Element     Strain     Element     Strain     Element     Strain     Element     Strain' &
           ,/,1X,A,'   ID                     ID                     ID                     ID                     ID')
-  
+
  1103 FORMAT(5(A,I8,1ES14.6))
 
  1104 FORMAT(A,I8,1ES14.6)
@@ -791,21 +791,21 @@
  1301 FORMAT(1X,A,'  Elem  Location            Epsilon-xx    Epsilon-yy    Epsilon-zz     Gamma-xy      Gamma-yz      Gamma-zx  ', &
              '   von Mises'                                                                                                        &
           ,/,1X,A,'   ID')
-  
+
  1302 FORMAT(1X,A,'  Elem  Location            Epsilon-xx    Epsilon-yy    Epsilon-zz     Gamma-xy      Gamma-yz      Gamma-zx  ', &
              '      Octahedral Strain'                                                                                             &
           ,/,1X,A,'   ID',109X,'Direct        Shear')
-  
+
  1303 FORMAT(1X,I8,2X,'CENTER  ',8X,8(1ES14.6))
 
 
  ! 1301 FORMAT(A,'Element   Epsilon-xx    Epsilon-yy    Epsilon-zz     Gamma-xy      Gamma-yz      Gamma-zx     von Mises'           &
           ! ,/,A,'   ID')
-  
+
  ! 1302 FORMAT(A,'Element   Epsilon-xx    Epsilon-yy    Epsilon-zz     Gamma-xy      Gamma-yz      Gamma-zx        ',                &
              ! 'Octahedral Strain'                                                                                                   &
           ! ,/,A,'   ID',91X,'Direct        Shear')
-  
+
  ! 1303 FORMAT(19X,I8,8(1ES14.6))
 
 
@@ -897,19 +897,19 @@
  1601 FORMAT(1X,A,'Element               S t r a i n s                            Element               S t r a i n s'             &
           ,/,1X,A,'   ID      Normal-X      Normal-Y      Shear-XY                   ID      Normal-X      Normal-Y'               &
                  ,'      Shear-XY')
-  
+
 
 ! TRIA3 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  1701 FORMAT(1X,A,'Element    Location      Fibre        Strains In Element Coord System       Principal Strains (Zero Shear)',    &
                 '                 Transverse   Transverse'                                                                         &
           ,/,1X,A,'   ID                   Distance     Normal-X     Normal-Y      Shear-XY     Angle     Major        Minor'      &
           ,'      von Mises    Shear-XZ     Shear-YZ',A)
-  
+
  1702 FORMAT(1X,A,'Element    Location      Fibre        Strains In Element Coord System       Principal Strains (Zero Shear)',    &
   '      Max        Transverse   Transverse'                                                                                       &
           ,/,1X,A,'   ID                   Distance     Normal-X     Normal-Y      Shear-XY     Angle     Major        Minor',     &
           '      Shear-XY    Shear-XZ     Shear-YZ',A)
-  
+
  1703 FORMAT(1X,I8,4X,'Anywhere',2X,4(1ES13.5),0PF9.3,5(1ES13.5))
 
  1704 FORMAT(13X,'in elem',3X,4(1ES13.5),0PF9.3,5(1ES13.5))
@@ -933,7 +933,7 @@
 ! BUSH >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  1801 FORMAT(20X,A,'Element    Strain-1      Strain-2      Strain-3      Strain-4      Strain-5      Strain-6'                     &
           ,/,20X,A,'   ID')
-  
+
  1802 FORMAT(19X,I8,6(1ES14.6))
 
  1812 FORMAT(16X,I8,6(1ES14.6))
@@ -941,7 +941,7 @@
 ! USERIN >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  1901 FORMAT(20X,A,'Element    Strain-1      Strain-2      Strain-3      Strain-4      Strain-5      Strain-6'                     &
           ,/,20X,A,'   ID')
-  
+
  1902 FORMAT(19X,I8,6(1ES14.6))
 
  1912 FORMAT(19X,I8,6(1ES14.6))
@@ -1023,8 +1023,8 @@
           !        RE1 = REAL(OGEL(I,1), 4)
           !        RE2 = REAL(OGEL(I,2), 4)
           !        RE3 = REAL(OGEL(I,3), 4)
-          !        
-          !        write the max_shear, avg_shear, 
+          !
+          !        write the max_shear, avg_shear,
           !        WRITE(OP2) RE1, RE2, RE3
           !    ENDDO
           !
@@ -1137,7 +1137,8 @@
       IF(.TRUE.) THEN
         DO I=1,NUM
            K = K + 1
-         WRITE(F06,*)                                         ; WRITE(ANS,*)
+         WRITE(F06,*)
+         IF (WRITE_ANS) WRITE(ANS,*)
          ! the J=1,10 loop is the upper layer & 2 transverse shear
          WRITE(F06,1703) EID_OUT_ARRAY(I,1),(OGEL(K,J),J=1,10)
          IF (WRITE_ANS) WRITE(ANS,1713) EID_OUT_ARRAY(I,1), (OGEL(K,J),J=1,10)
@@ -1155,7 +1156,7 @@
       WRITE(F06,1705) MAX_ANS(2),MAX_ANS(3),MAX_ANS(4),MAX_ANS(6),MAX_ANS(7),MAX_ANS(8),MAX_ANS(9),MAX_ANS(10),                 &
                       MIN_ANS(2),MIN_ANS(3),MIN_ANS(4),MIN_ANS(6),MIN_ANS(7),MIN_ANS(8),MIN_ANS(9),MIN_ANS(10),                 &
                       ABS_ANS(2),ABS_ANS(3),ABS_ANS(4),ABS_ANS(6),ABS_ANS(7),ABS_ANS(8),ABS_ANS(9),ABS_ANS(10)
-                      
+
       ENDIF
 
       IF(WRITE_ANS) THEN

--- a/Source/LK9/L91/WRITE_ELEM_STRESSES.f90
+++ b/Source/LK9/L91/WRITE_ELEM_STRESSES.f90
@@ -1,31 +1,31 @@
 ! ##################################################################################################################################
-! Begin MIT license text.                                                                                    
+! Begin MIT license text.
 ! _______________________________________________________________________________________________________
-                                                                                                         
-! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)                                              
-                                                                                                         
-! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and      
+
+! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 ! associated documentation files (the "Software"), to deal in the Software without restriction, including
 ! without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to   
-! the following conditions:                                                                              
-                                                                                                         
-! The above copyright notice and this permission notice shall be included in all copies or substantial   
-! portions of the Software and documentation.                                                                              
-                                                                                                         
-! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS                                
-! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                            
-! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                            
-! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                                 
-! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                          
-! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                              
-! THE SOFTWARE.                                                                                          
+! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to
+! the following conditions:
+
+! The above copyright notice and this permission notice shall be included in all copies or substantial
+! portions of the Software and documentation.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
 ! _______________________________________________________________________________________________________
-                                                                                                        
-! End MIT license text.                                                                                      
-  
+
+! End MIT license text.
+
       SUBROUTINE WRITE_ELEM_STRESSES ( JSUB, NUM, IHEADER, NUM_PTS, ITABLE )
-  
+
       ! Writes blocks of element stresses for one subcase and one element type for elements that do not have PCOMP properties, including
       ! all 1-D, 2-D, 3-D elements.
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
@@ -41,11 +41,11 @@
       USE LINK9_STUFF, ONLY           :  EID_OUT_ARRAY, GID_OUT_ARRAY, OGEL, POLY_FIT_ERR, POLY_FIT_ERR_INDEX
       USE MODEL_STUF, ONLY            :  ELEM_ONAME, ELMTYP, LABEL, SCNUM, STITLE, TITLE, TYPE
       USE CC_OUTPUT_DESCRIBERS, ONLY  :  STRE_LOC, STRE_OPT, STRE_OUT
-  
+
       USE WRITE_ELEM_STRESSES_USE_IFs
 
       IMPLICIT NONE
- 
+
       CHARACTER(LEN=LEN(BLNK_SUB_NAM)):: SUBR_NAME = 'WRITE_ELEM_STRESSES'
       CHARACTER(LEN=*), INTENT(IN)    :: IHEADER           ! Indicator of whether to write an output header
 
@@ -57,7 +57,7 @@
 
                                                            ! Indicators of whether to write note on indices of POLY_FIT_ERR
       CHARACTER( 1*BYTE)              :: WRT_ERR_INDEX_NOTE(MAX_NUM_STR)
-  
+
       INTEGER(LONG), INTENT(IN)       :: JSUB              ! Solution vector number
       INTEGER(LONG), INTENT(IN)       :: NUM               ! The number of rows of OGEL to write out
       INTEGER(LONG), INTENT(IN)       :: NUM_PTS           ! Num diff stress points for one element (3rd dim in arrays SEi, STEi)
@@ -69,11 +69,11 @@
       INTEGER(LONG)                   :: K                 ! Counter
       INTEGER(LONG)                   :: NCOLS             ! Num of cols to write out
       INTEGER(LONG), PARAMETER        :: SUBR_BEGEND = WRITE_ELEM_STRESSES_BEGEND
-  
+
       REAL(DOUBLE)                    :: ABS_ANS(11)       ! Max ABS for all element output
       REAL(DOUBLE)                    :: MAX_ANS(11)       ! Max for all element output
       REAL(DOUBLE)                    :: MIN_ANS(11)       ! Min for all element output
-      
+
       ! op2 info
       CHARACTER( 8*BYTE)              :: TABLE_NAME             ! the name of the op2 table
       INTEGER(LONG)                   :: NNODES                 ! number of nodes for the element
@@ -97,7 +97,7 @@
       INTEGER(LONG)                   :: NVALUES          ! the number of "words" for all the elments
       INTEGER(LONG)                   :: NTOTAL           ! the number of bytes for all NVALUES
       INTEGER(LONG)                   :: ISUBCASE         ! the subcase ID
-      INTEGER(LONG)                   :: NELEMENTS        
+      INTEGER(LONG)                   :: NELEMENTS
       INTEGER(LONG)                   :: ISUBCASE_INDEX   ! the index into SCNUM
       INTEGER(LONG)                   :: CID              ! coordinate system
       CHARACTER(4*BYTE)               :: CEN_WORD         ! the word "CEN/" (we need to cast the length)
@@ -195,7 +195,7 @@
 
          ELSE IF (SOL_NAME(1:12) == 'GEN CB MODEL') THEN
             ISUBCASE_INDEX = 1  ! modes
-            IF ((JSUB <= NDOFR) .OR. (JSUB >= NDOFR+NVEC)) THEN 
+            IF ((JSUB <= NDOFR) .OR. (JSUB >= NDOFR+NVEC)) THEN
                IF (JSUB <= NDOFR) THEN
                   BDY_DOF_NUM = JSUB
                ELSE
@@ -230,7 +230,7 @@
          TITLEI = TITLE(INT_SC_NUM)
          STITLEI = STITLE(INT_SC_NUM)
          LABELI = LABEL(INT_SC_NUM)
-         
+
          IF (WRITE_F06) THEN
              IF (TITLE(INT_SC_NUM)(1:)  /= ' ') THEN
                  WRITE(F06,201) TITLE(INT_SC_NUM)
@@ -419,7 +419,7 @@
 
              NUM_WIDE = 2 ! eid, spring_stress
              NVALUES = NUM_WIDE * NUM
-             
+
              DEVICE_CODE = 1   ! PLOT
 
              !CALL GET_STRESS_CODE(STRESS_CODE, IS_VON_MISES, IS_STRAIN, IS_FIBER_DISTANCE)
@@ -539,8 +539,8 @@
               ! CQUAD4-33
   2           FORMAT(' *DEBUG:  WRITE_CQUAD4-33:  NUM=',I4, " NUM_PTS=", I4, " STRE_LOC=",A,"ITABLE=",I4)
               WRITE(ERR,2) NUM,NUM_PTS,STRE_LOC,ITABLE
-       
-              !(eid_device, 
+
+              !(eid_device,
               ! fd1, sx1, sy1, txy1, angle1, major1, minor1, vm1,
               ! fd2, sx2, sy2, txy2, angle2, major2, minor2, vm2,) = out; n=17
               NUM_WIDE = 17
@@ -559,7 +559,7 @@
               WRITE(ERR,3) NUM,NUM_PTS,STRE_LOC,ITABLE
               ELEMENT_TYPE = 144
               NUM_WIDE = 87 ! 2 + 17 * (4+1)  ! 4 nodes + 1 centroid
-              
+
               ! TODO: probably wrong...divide NUM by NUM_PTS?
               NELEMENTS = NUM / NUM_PTS
               NVALUES = NUM_WIDE * NELEMENTS
@@ -652,13 +652,13 @@
              ! Get abs POLY_FIT_ERR
          ABS_ANS(11) = MAX( DABS(MAX_ANS(11)), DABS(MIN_ANS(11)) )
 
-         IF ((STRE_LOC == 'CORNER  ') .OR. (TYPE(1:5) == 'QUAD8')) THEN 
+         IF ((STRE_LOC == 'CORNER  ') .OR. (TYPE(1:5) == 'QUAD8')) THEN
             WRITE(F06,1408) FILL(1: 0), FILL(1: 0), MAX_ANS(2),MAX_ANS(3),MAX_ANS(4),MAX_ANS(6),MAX_ANS(7),MAX_ANS(8),MAX_ANS(9),  &
                                                     MAX_ANS(10),MAX_ANS(11),                                                       &
                             FILL(1: 0),             MIN_ANS(2),MIN_ANS(3),MIN_ANS(4),MIN_ANS(6),MIN_ANS(7),MIN_ANS(8),MIN_ANS(9),  &
                                                     MIN_ANS(10),MIN_ANS(11),                                                       &
                             FILL(1: 0),             ABS_ANS(2),ABS_ANS(3),ABS_ANS(4),ABS_ANS(6),ABS_ANS(7),ABS_ANS(8),ABS_ANS(9),  &
-                                                    ABS_ANS(10),ABS_ANS(11), FILL(1: 0)  
+                                                    ABS_ANS(10),ABS_ANS(11), FILL(1: 0)
          ELSE
             WRITE(F06,1408) FILL(1: 0), FILL(1: 0), MAX_ANS(2),MAX_ANS(3),MAX_ANS(4),MAX_ANS(6),MAX_ANS(7),MAX_ANS(8),MAX_ANS(9),  &
                                                     MAX_ANS(10),MAX_ANS(11),                                                       &
@@ -669,7 +669,7 @@
          ENDIF
 
          IF (WRITE_ANS) THEN
-            IF ((STRE_LOC == 'CORNER  ') .OR. (TYPE(1:5) == 'QUAD8')) THEN 
+            IF ((STRE_LOC == 'CORNER  ') .OR. (TYPE(1:5) == 'QUAD8')) THEN
                WRITE(ANS,1418)MAX_ANS(2),MAX_ANS(3),MAX_ANS(4),MAX_ANS(6),MAX_ANS(7),MAX_ANS(8),MAX_ANS(9),MAX_ANS(10),MAX_ANS(11),&
                               MIN_ANS(2),MIN_ANS(3),MIN_ANS(4),MIN_ANS(6),MIN_ANS(7),MIN_ANS(8),MIN_ANS(9),MIN_ANS(10),MIN_ANS(11),&
                               ABS_ANS(2),ABS_ANS(3),ABS_ANS(4),ABS_ANS(6),ABS_ANS(7),ABS_ANS(8),ABS_ANS(9),ABS_ANS(10)
@@ -679,14 +679,14 @@
                               ABS_ANS(2),ABS_ANS(3),ABS_ANS(4),ABS_ANS(6),ABS_ANS(7),ABS_ANS(8),ABS_ANS(9),ABS_ANS(10),ABS_ANS(11)
             ENDIF
          ENDIF
-             
+
          WRITE_NOTES = 'N'
          DO I=1,MAX_NUM_STR
             IF (WRT_ERR_INDEX_NOTE(I) == 'Y') THEN
                WRITE_NOTES = 'Y'
             ENDIF
          ENDDO
-   
+
          IF (WRITE_NOTES == 'Y') THEN
             WRITE(F06,1498)
             DO I=1,MAX_NUM_STR
@@ -735,8 +735,8 @@
          ENDDO
 
       ELSE
-         WRITE(ERR,9300) SUBR_NAME,TYPE                           
-         WRITE(F06,9300) SUBR_NAME,TYPE                          
+         WRITE(ERR,9300) SUBR_NAME,TYPE
+         WRITE(F06,9300) SUBR_NAME,TYPE
          FATAL_ERR = FATAL_ERR + 1
          CALL OUTA_HERE ( 'Y' )                            ! Coding error (elem type not valid) , so quit
       ENDIF
@@ -762,12 +762,12 @@
   201 FORMAT(1X,A)
 
   301 FORMAT(A,'E L E M E N T   S T R E S S E S   I N   L O C A L   E L E M E N T   C O O R D I N A T E   S Y S T E M')
-  
+
   302 FORMAT(A,'C B   E L E M E N T   S T R E S S E S   O T M   I N   L O C A L   E L E M E N T   C O O R D I N A T E',            &
   '   S Y S T E M')
-  
+
   401 FORMAT(A,'F O R   E L E M E N T   T Y P E   ',A11)
- 
+
 
 
 ! BAR >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -784,7 +784,7 @@
 ! ELAS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  1201 FORMAT(1X,A,'Element     Stress     Element     Stress     Element     Stress     Element     Stress     Element     Stress' &
           ,/,1X,A,'   ID                     ID                     ID                     ID                     ID')
-  
+
  1103 FORMAT(5(A,I8,1ES14.6))
 
  1104 FORMAT(A,I8,1ES14.6)
@@ -794,11 +794,11 @@
  1301 FORMAT(1X,A,'  Elem  Location            Sigma-xx      Sigma-yy      Sigma-zz       Tau-xy        Tau-yz        Tau-zx    ', &
              '   von Mises'                                                                                                        &
           ,/,1X,A,'   ID')
-  
+
  1302 FORMAT(1X,A,'  Elem  Location            Sigma-xx      Sigma-yy      Sigma-zz       Tau-xy        Tau-yz        Tau-zx    ', &
              '      Octahedral Stress'                                                                                             &
           ,/,1X,A,'   ID',109X,'Direct        Shear')
-  
+
  1303 FORMAT(1X,I8,2X,'CENTER  ',8X,8(1ES14.6))
 
  1304 FORMAT(28X,'------------- ------------- ------------- ------------- ------------- ------------- -------------',/,            &
@@ -887,7 +887,7 @@
  1601 FORMAT(1X,A,'Element              S t r e s s e s                           Element              S t r e s s e s'   &
           ,/,1X,A,'   ID      Normal-X      Normal-Y      Shear-XY                   ID      Normal-X      Normal-Y'               &
                  ,'      Shear-XY')
-  
+
 
 ! TRIA3 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  1701 FORMAT(1X,A,'Element    Location      Fibre        Stresses In Element Coord System       Principal Stresses (Zero Shear)',  &
@@ -895,12 +895,12 @@
           ,/,1X,A,'   ID                   Distance     Normal-X     Normal-Y      Shear-XY     Angle     Major        Minor'      &
           ,'      von Mises     Shear-XZ     Shear-YZ'                                                                             &
           ,/,1X,A,123X,'(max through thickness)')
-  
+
  1702 FORMAT(1X,A,'Element    Location      Fibre        Stresses In Element Coord System       Principal Stresses (Zero Shear)',  &
   '      Max      Transverse   Transverse'                                                                                         &
           ,/,1X,A,'   ID                   Distance     Normal-X     Normal-Y      Shear-XY     Angle     Major        Minor',     &
           '      Shear-XY     Shear-XZ     Shear-YZ',/,1X,123X,'(max through thickness)')
-  
+
  1703 FORMAT(1X,I8,4X,'Anywhere',2X,4(1ES13.5),0PF9.3,5(1ES13.5))
 
  1704 FORMAT(13X,'in elem',3X,4(1ES13.5),0PF9.3,5(1ES13.5))
@@ -924,7 +924,7 @@
 ! BUSH >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  1801 FORMAT(20X,A,'Element   Stress-1      Stress-2      Stress-3      Stress-4      Stress-5      Stress-6'                      &
           ,/,20X,A,'   ID')
-  
+
  1802 FORMAT(19X,I8,8(1ES14.6))
 
  1812 FORMAT(16X,I8,8(1ES14.6))
@@ -932,7 +932,7 @@
 ! USERIN >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
  1901 FORMAT(20X,A,'Element   Stress-1      Stress-2      Stress-3      Stress-4      Stress-5      Stress-6'                      &
           ,/,20X,A,'   ID')
-  
+
  1902 FORMAT(19X,I8,8(1ES14.6))
 
  1912 FORMAT(17X,I8,8(1ES14.6))
@@ -1011,8 +1011,8 @@
           !        RE1 = REAL(OGEL(I,1), 4)
           !        RE2 = REAL(OGEL(I,2), 4)
           !        RE3 = REAL(OGEL(I,3), 4)
-          !        
-          !        write the max_shear, avg_shear, 
+          !
+          !        write the max_shear, avg_shear,
           !        WRITE(OP2) RE1, RE2, RE3
           !    ENDDO
           !
@@ -1099,12 +1099,12 @@
           CALL WRITE_OES3_STATIC(ITABLE, ISUBCASE, DEVICE_CODE, ELEMENT_TYPE, NUM_WIDE, STRESS_CODE, &
                                  TITLE, SUBTITLE, LABEL, FIELD5_INT_MODE, FIELD6_EIGENVALUE)
           WRITE(OP2) NVALUES
-     
+
 !1702     FORMAT(1X,A,'Element    Location      Fibre        Stresses In Element Coord System       Principal Stresses (Zero Shear)', &
 !  '          Max      Transverse   Transverse'                                                                                       &
 !              ,/,1X,A,'   ID                   Distance     Normal-X     Normal-Y      Shear-XY     Angle     Major        Minor',   &
 !              '      Shear-XY     Shear-XZ     Shear-YZ',/,1X,123X,'(max through thickness)')
-     
+
           ! op2 version of the upper & lower layers all in one call, but without the transverse shear
           WRITE(OP2) (EID_OUT_ARRAY(I,1)*10+DEVICE_CODE, (REAL(OGEL(2*I-1,J),4), J=1,8), &
                      (REAL(OGEL(2*I,J),4), J=1,8), I=1,NUM)
@@ -1131,7 +1131,7 @@
       DO I=1,NUM
          K = K + 1
          WRITE(F06,*)
-         WRITE(ANS,*)
+         IF (WRITE_ANS) WRITE(ANS,*)
          ! the J=1,10 loop is the upper layer & 2 transverse shear
          WRITE(F06,1703) EID_OUT_ARRAY(I,1),(OGEL(K,J),J=1,10)
          IF (WRITE_ANS) WRITE(ANS,1713) EID_OUT_ARRAY(I,1), (OGEL(K,J),J=1,10)
@@ -1146,7 +1146,7 @@
       WRITE(F06,1705) MAX_ANS(2),MAX_ANS(3),MAX_ANS(4),MAX_ANS(6),MAX_ANS(7),MAX_ANS(8),MAX_ANS(9),MAX_ANS(10),                 &
                       MIN_ANS(2),MIN_ANS(3),MIN_ANS(4),MIN_ANS(6),MIN_ANS(7),MIN_ANS(8),MIN_ANS(9),MIN_ANS(10),                 &
                       ABS_ANS(2),ABS_ANS(3),ABS_ANS(4),ABS_ANS(6),ABS_ANS(7),ABS_ANS(8),ABS_ANS(9),ABS_ANS(10)
-                      
+
 
       IF (WRITE_ANS) THEN
          WRITE(ANS,1715) MAX_ANS(2),MAX_ANS(3),MAX_ANS(4),MAX_ANS(6),MAX_ANS(7),MAX_ANS(8),MAX_ANS(9),MAX_ANS(10),  &

--- a/Source/UTIL/OUTPUT2_UTILS.f90
+++ b/Source/UTIL/OUTPUT2_UTILS.f90
@@ -58,22 +58,26 @@
 
 !===================================================================================================================================
       SUBROUTINE  END_OP2_TABLES()
-      USE IOUNT1, ONLY                :  ERR, OP2
+      USE IOUNT1, ONLY                :  ERR, OP2, OP2FIL
       IMPLICIT NONE
+      LOGICAL                         :: FILE_OPND
  9115 FORMAT(" *DEBUG:       END_OP2_TABLES", A)
       WRITE(ERR,9115) " "
-      WRITE(OP2) 0
+      INQUIRE ( FILE=OP2FIL, OPENED=FILE_OPND )
+      IF (FILE_OPND) THEN
+        WRITE(OP2) 0
+      ENDIF
       END SUBROUTINE END_OP2_TABLES
 
 !===================================================================================================================================
       SUBROUTINE WRITE_OP2_GEOM()
       USE PENTIUM_II_KIND, ONLY       :  LONG, BYTE
       USE IOUNT1, ONLY                :  ERR, OP2
-      
+
       ! GEOM1 - GRID/COORDs
       USE SCONTR, ONLY                :  NGRID
       USE MODEL_STUF, ONLY            :  GRID_ID, GRID
-      
+
       ! GEOM2 - elements
       !USE MODEL_STUF, ONLY : ELAS1, ELAS2, ELAS3, ELAS4, ROD, TETRA4, TETRA10
       USE SCONTR, ONLY : NCTETRA4, NCTETRA10, NCPENTA6, NCPENTA15, NCHEXA8, NCHEXA20
@@ -118,7 +122,7 @@
  1    FORMAT("****DEBUG:   WRITE_OP2 GEOM ngrid",i4)
       IF (IS_GEOM1) THEN
         WRITE(ERR,1) NGRID
-      
+
         TABLE_NAME = "GEOM1"
         CALL WRITE_OP2_GEOM_HEADER(TABLE_NAME, ITABLE)
 
@@ -140,7 +144,7 @@
           ! is GRID_ID(I) the same as GRID(I,1)???
           !
           !(nid, cp, x1, x2, x3, cd, ps, seid)
-          !                        nid        cp         x                   y                   z                  
+          !                        nid        cp         x                   y                   z
         !  WRITE(ERR,2) GRID_ID(I), GRID(I,1), GRID(I,2), REAL(RGRID(I,1),4), REAL(RGRID(I,2),4), REAL(RGRID(I,3),4), &
           !            cd         ps         ndof
         !               GRID(I,3), GRID(I,4), GRID(I,6)
@@ -160,7 +164,7 @@
       USE SCONTR, ONLY            :  NPROD
       USE MODEL_STUF, ONLY        :  PROD
       USE IOUNT1, ONLY            :  ERR
- 
+
       INTEGER(LONG), INTENT(IN)    :: PID
       INTEGER(LONG), INTENT(INOUT) :: IPROD
       INTEGER(LONG)                :: I
@@ -177,14 +181,14 @@
  2    FORMAT("GET_PROD_INDEX MID:  *********FOUND PID=",i4)
  3    FORMAT("GET_PROD_INDEX END:  PID=",i4,"; IPROD=",i4,"; PROD(I,1)=",i4)
       END SUBROUTINE GET_PROD_INDEX
-     
+
 !===================================================================================================================================
       SUBROUTINE WRITE_OP2_GEOM_EPT()
       ! writes the element property table (EPT)
       USE PENTIUM_II_KIND, ONLY       :  LONG, BYTE
       USE IOUNT1, ONLY                :  ERR, OP2
-      USE SCONTR, ONLY : NPELAS, NPROD, NPBUSH, NPCOMP, NPSHEAR, NPSOLID ! NPSHELL, 
-      USE MODEL_STUF, ONLY : PELAS, PROD, PBAR, PBEAM, PSHEAR, PCOMP, PSOLID ! PSHELL, 
+      USE SCONTR, ONLY : NPELAS, NPROD, NPBUSH, NPCOMP, NPSHEAR, NPSOLID ! NPSHELL,
+      USE MODEL_STUF, ONLY : PELAS, PROD, PBAR, PBEAM, PSHEAR, PCOMP, PSOLID ! PSHELL,
       USE MODEL_STUF, ONLY : RPELAS, RPROD, RPROD, RPBAR, RPBEAM, RPSHEAR, RPCOMP ! RPSHELL, RPSOLID
 
       IMPLICIT NONE
@@ -223,7 +227,7 @@
 
       IF (IS_EPT) THEN
         CALL WRITE_OP2_GEOM_HEADER(TABLE_NAME, ITABLE)
-        
+
         IF (NPROD > 0) THEN
           NUM_WIDE = 6
           ! (pid, mid, a, j, c, nsm)

--- a/Source/UTIL/WRITE_DOF_TABLES.f90
+++ b/Source/UTIL/WRITE_DOF_TABLES.f90
@@ -1,39 +1,40 @@
 ! ##################################################################################################################################
-! Begin MIT license text.                                                                                    
+! Begin MIT license text.
 ! _______________________________________________________________________________________________________
-                                                                                                         
-! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)                                              
-                                                                                                         
-! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and      
+
+! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 ! associated documentation files (the "Software"), to deal in the Software without restriction, including
 ! without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to   
-! the following conditions:                                                                              
-                                                                                                         
-! The above copyright notice and this permission notice shall be included in all copies or substantial   
-! portions of the Software and documentation.                                                                              
-                                                                                                         
-! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS                                
-! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                            
-! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                            
-! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                                 
-! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                          
-! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                              
-! THE SOFTWARE.                                                                                          
+! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to
+! the following conditions:
+
+! The above copyright notice and this permission notice shall be included in all copies or substantial
+! portions of the Software and documentation.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
 ! _______________________________________________________________________________________________________
-                                                                                                        
-! End MIT license text.                                                                                      
+
+! End MIT license text.
 
       SUBROUTINE WRITE_DOF_TABLES
 
 ! Writess DOF table data to file LINK1C
 
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
-      USE IOUNT1, ONLY                :  WRT_LOG, F04, L1C, LINK1C, L1C_MSG
+      USE IOUNT1, ONLY                :  WRT_LOG, F04, L1C, LINK1C, L1C_MSG, ERR, F06
       USE SCONTR, ONLY                :  DATA_NAM_LEN, MTDOF, NDOFG, NGRID, BLNK_SUB_NAM
       USE TIMDAT, ONLY                :  TSEC
       USE SUBR_BEGEND_LEVELS, ONLY    :  WRITE_DOF_TABLES_BEGEND
       USE DOF_TABLES, ONLY            :  TDOFI, TDOF, TSET
+      USE NONLINEAR_PARAMS, ONLY      :  LOAD_ISTEP
 
       USE WRITE_DOF_TABLES_USE_IFs
 
@@ -44,6 +45,7 @@
 
       INTEGER(LONG)                   :: I,J               ! DO loop indices or counters
       INTEGER(LONG), PARAMETER        :: SUBR_BEGEND = WRITE_DOF_TABLES_BEGEND
+      INTEGER(LONG)                   :: OUNT(2)           ! File units to write messages to. Input to subr UNFORMATTED_OPEN
 
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN
@@ -55,6 +57,13 @@
 ! **********************************************************************************************************************************
 ! Write TSET, TDOF, TDOFI tables to file L1C
 
+      ! Ensure L1C is open. if this is a two-step run, we need to reopen L1C.
+      IF (LOAD_ISTEP > 1) THEN
+         OUNT(1) = ERR
+         OUNT(2) = F06
+         CALL FILE_OPEN ( L1C, LINK1C, OUNT, 'REPLACE', L1C_MSG, 'WRITE_STIME', 'UNFORMATTED', 'WRITE', 'REWIND', 'Y', 'N', 'Y' )
+      ENDIF
+
       DATA_SET_NAME = 'TSET'
       WRITE(L1C) DATA_SET_NAME
       WRITE(L1C) NGRID
@@ -62,7 +71,7 @@
          DO J = 1,6
            WRITE(L1C) TSET(I,J)
          ENDDO
-      ENDDO 
+      ENDDO
       DATA_SET_NAME = 'TDOFI'
       WRITE(L1C) DATA_SET_NAME
       WRITE(L1C) NDOFG
@@ -71,7 +80,7 @@
          DO J = 1,MTDOF
             WRITE(L1C) TDOFI(I,J)
          ENDDO
-      ENDDO 
+      ENDDO
       DATA_SET_NAME = 'TDOF'
       WRITE(L1C) DATA_SET_NAME
       WRITE(L1C) NDOFG
@@ -80,7 +89,7 @@
          DO J = 1,MTDOF
             WRITE(L1C) TDOF(I,J)
          ENDDO
-      ENDDO 
+      ENDDO
 
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN


### PR DESCRIPTION
# What are fort.N files?

First, some background: for some reason, Fortran lets you write to unconnected units. So, if you write to unit, say, `123`, without opening a filename to associate it with that unit number, the runtime will create a file called `fort.123` and your writes, closes, deletions, etc. will happen to it. Maybe that was an useful feature back when programs were stored on punch cards, but nowadays all it does is silently disguise programmer oversights.

MYSTRAN, thankfully, does not rely on such behaviour: all of its unit numbers are matched to specific files, like `ANS` -> `ANSFIL`, `L1C` -> `LINK1C`, etc., save for `SC1` (standard output). However, programmer oversights can still allow for the creation of `fort.N` files: all that needs to happen is a `WRITE` to an unit number that has not yet been opened with `FILE_OPEN`.

# How do they affect MYSTRAN?

When that happens, three kinds of issues can arise:

  1. Split file contents: output doesn't go where it's supposed to. That could break a run if it's a scratch file, or impact user output.
  2. Extraneous files remaining: users can get confused by fort.N files left on the run directory.
  3. Crashes when running MYSTRAN in parallel: see next section.

# How was this issue even found?

Such oversights were very rare, and did not impact important files, so this went under the radar. Anyone who ran/debugged MYSTRAN regualrly probably *saw* a `fort.N` file at some point, and didn't care. I know I did!

That was, until last week, when I was running my test script in preparation for v17. What it does, put simply, is run MYSTRAN in parallel with 400+ decks, inside `valgrind`, to look for memory issues, runtime crashes, and the like. I noticed some buckling decks were crashing nondeterministically, but without memory issues: they were complaining about `IOSTAT` being `2` when *closing* the ANS file. Worse yet, that only happened when run inside the testing script: each of the decks had no issues when run manually.

So, when `IOSTAT` is positive and below `5000` on a binary built with `gfortran`, that means it's an `errno` value set by an OS error. Well, `errno` being `2` means `ENOENT`, also known as "no such file or directory". That's kind of a weird error for when you are *closing* a file!

Investigating further, I decided to set `DEBUG(193)=9`, making MYSTRAN print out, for each file, whether the unit is opened, and whether the file exists. Right before the crash... the `ANS` was reported as neither opened nor existing. That's... weirder.

The run didn't request ANS output, so that means that LINK9 closed the `ANS` unit with the `DELETE` flag, so the `ENOENT` was coming from a call to delete the file. That part makes sense. But why was it trying to delete a file corresponding to an unopened unit, and why did the file not exist?

That's the catch: when MYSTRAN calls INQUIRE to tell if a file exists and is opened, it checks the *filename*. So if, say, an oversight made MYSTRAN write to `ANS` (unit number `1`) before it was even opened, `fort.1` is created. So it makes sense that `deck_name.ANS` was reported as being neither opened nor existing. But why did `fort.1` not exist when MYSTRAN tried to close unit `1`?

Here's where the part about parallel runs comes in. Normally, you can run many different decks in the same directory, since all files a run touches (temporary or not) have the deck name as a prefix: `deck1.DAT` produces `deck1.F06`, `deck1.ANS`, `deck1.OP2`, `deck1.L4C`, etc. That means another instance of MYSTRAN would have no problem running `deck2.DAT` in the same working directory.

Except... `fort.N` files don't have deck names in them. So this could happen:

  1. Instance A of MYSTRAN creates `fort.1` due to a programming slip-up. ANS output was not requested, so `fort.1` is due to be deleted upon being closed at the end of `LINK9`.
  2. Instance B of MYSTRAN, running a similar deck on the same directory, also "creates" (opens) the same `fort.1`
  3. Instance A finishes up and deletes `fort.1` at the end of `LINK9`.
  4. Instance B also reaches the end of `LINK9` and attempts to close (and thus delete) its `ANS` unit, connected to `fort.1`, which has been deleted by instance A, so the underlying call to `unlink` sets `errno` to `2` (`ENOENT`).
  5. Instance B's `FILE_CLOSE` sees that nonzero `IOSTAT`, issues an error message, and stops dead.

That's what was happening when I was running my script.

# Why did this stay under the radar so long?

Only three `fort.N` file creations are currently known, `fort.1` (ANS), `fort.14` (OP2) and `fort.103` (L1C). Here's why each of them never came up before: 

  - `fort.1` is user output, and only written to on buckling decks. It's safely deleted at the end of `LINK9` regardless. The crash requires parallel runs of bucling decks that *do not* request ANS.
  - `fort.14` is OP2, but only created when `OUTA_HERE` is called (i.e. a fatal error), since part of its cleanup routine is to close output files, including writing a single zero to the OP2 unit without checking if it's even open.
  - `fort.103` is `L1C`, it contains some DOF tables... it *could* cause problems, but it doesn't. It's created and used normally throughout the second step of a two-step run (`L1C` is opened during `LINK0`, which only runs on the first step).

# So what's in this PR?

It gets rid of all of the three `fort.N` files mentioned above:

  1. `fort.1`: added `IF (WRITE_ANS)` checks to some writes to `ANS` that got away;
  2. `fort.14`: only write a zero to `OP2` if it's open;
  3. `fort.103`: re-open `L1C` during `LINK1` if and only if we're on the second step of a two-step run.

# But how did you find these writes?

All I had to do was run MYSTRAN inside a debugger and set a very cool breakpoint: `break open if strstr($rdi,"fort.") != 0`. You'd probably need to change `$rdi` depending on your OS and architecture. I'm not even sure it *works* on Windows!

# How can you be sure that you got all of them?

I ran the same 400+ deck set with that breakpoint in a `gdb` script:

```gdb
set breakpoint pending on
set logging redirect on
set logging file /dev/stderr
set logging overwrite on
set logging on
break main
commands
  silent
  break open if strstr($rdi,"fort.") != 0
  commands
    silent
    printf "\n\n===== created %s while running %s =====\n\n", (char*)$rdi, __libc_argv[1]
    backtrace
    printf "\n===== end of trace =====\n"
    continue
  end
  continue
end
run
```

Then you can just `gdb -batch catch_fort.gdb mystran somefile.dat >/dev/null` and check out `stderr`.

None of the decks were caught causing calls to `open` on paths containing `fort.`. That's good enough for me.

# Are these fixes safe?

The only one with even a potential for risk is reopening `L1C`. It looks ugly, and that's because `L1C` is opened during `LINK0`, which does not run on the second step of a buckling deck. Ugly, but harmless. All of the other fixes are merely "check before writing" and it's user output file (ANS and OP2), so nothing should break. Hell, the OP2 one only shows up during FATALs.

Given all that, I'm pretty confident these fixes are safe. 