### PR TITLE
SuperLU for Lanczos

### DIFF
--- a/Source/LK1/L1A-BD/BD_PARAM.f90
+++ b/Source/LK1/L1A-BD/BD_PARAM.f90
@@ -1113,17 +1113,19 @@
          CALL CHAR_FLD ( JCARD(3), JF(3), CHRPARM )
          IF (IERRFL(3) == 'N') THEN
             CALL LEFT_ADJ_BDFLD ( CHRPARM )
-            IF      (CHRPARM == 'ARPACK  ') THEN
-               LANCMETH = 'ARPACK'
+            IF      (CHRPARM == 'BANDED  ') THEN
+               LANCMETH = 'BANDED'
+            ELSE IF (CHRPARM == 'SPARSE  ') THEN
+               LANCMETH = 'SPARSE'
             ELSE
                WARN_ERR = WARN_ERR + 1
                WRITE(ERR,101) CARD
-               WRITE(ERR,1189) PARNAM,'ARPACK',CHRPARM,SOLLIB
+               WRITE(ERR,1189) PARNAM,'BANDED or SPARSE',CHRPARM,LANCMETH
                IF (SUPWARN == 'N') THEN
                   IF (ECHO == 'NONE  ') THEN
                      WRITE(F06,101) CARD
                   ENDIF
-                  WRITE(F06,1189) PARNAM,'ARPACK',CHRPARM,SOLLIB
+                  WRITE(F06,1189) PARNAM,'BANDED or SPARSE',CHRPARM,LANCMETH
                ENDIF
             ENDIF
          ENDIF

--- a/Source/Modules/PARAMS.f90
+++ b/Source/Modules/PARAMS.f90
@@ -196,7 +196,7 @@
       CHARACTER(  1*BYTE)      :: KOORAT         =    'Y'    ! 'Y', 'N' to tell whether to calc ratio of max/min KOO diagonal terms
 
 ! ----------------------------------------------------------------------------------------------------------------------------------
-      CHARACTER(  6*BYTE)      :: LANCMETH       = 'ARPACK'  ! Lanczos method - ARPACK
+      CHARACTER(  6*BYTE)      :: LANCMETH       = 'BANDED'  ! Lanczos method - BANDED or SPARSE
 
 ! ----------------------------------------------------------------------------------------------------------------------------------
       CHARACTER(  1*BYTE)      :: MATSPARS       =    'Y'    ! 'Y' for use of sparse SFF, SFS, SSS or 'N' for full matrix add/mult


### PR DESCRIPTION
PARAM,LANCMETH changed from only having one value ARPACK to two values:
- BANDED (default) or
- SPARSE to enable SuperLU for EIGRL

In SPARSE mode, it doesn't allocate the banded matrix so it doesn't explode the memory use, and it runs SuperLU instead of ARPACK.

SPARSE is much faster than BANDED but also gave erroneous eigenvalues and eigenvectors on a 35000 grid point test case. OK on smaller ones.