### PR TITLE
fixed mass distribution in solid mass matrices

### DIFF
--- a/Source/EMG/EMG5/PENTA.f90
+++ b/Source/EMG/EMG5/PENTA.f90
@@ -40,7 +40,7 @@
       USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, F06
       USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR, MAX_ORDER_TRIA, MAX_ORDER_GAUSS, NTSUB
       USE TIMDAT, ONLY                :  TSEC
-      USE CONSTANTS_1, ONLY           :  HALF, THIRD, ZERO, SIX
+      USE CONSTANTS_1, ONLY           :  HALF, THIRD, ZERO
       USE DEBUG_PARAMETERS, ONLY      :  DEBUG
       USE SUBR_BEGEND_LEVELS, ONLY    :  PENTA_BEGEND
       USE PARAMS, ONLY                :  EPSIL
@@ -49,7 +49,8 @@
                                          SE1, SE2, STE1, STRESS, TREF, TYPE
  
       USE PENTA_USE_IFs
-
+      USE LUMP_MASS_Interface
+      
       IMPLICIT NONE 
   
       CHARACTER(LEN=LEN(BLNK_SUB_NAM)):: SUBR_NAME = 'PENTA'
@@ -104,7 +105,6 @@
       REAL(DOUBLE)                    :: JAC(3,3)                ! An output from subr JAC3D, called herein. 3 x 3 Jacobian matrix.
       REAL(DOUBLE)                    :: JACI(3,3)               ! An output from subr JAC3D, called herein. 3 x 3 Jacobian inverse.
       REAL(DOUBLE)                    :: KWW(3,3)                ! Portion of differential stiffness matrix
-      REAL(DOUBLE)                    :: M0                      ! An intermediate variable used in calc elem mass, ME
       REAL(DOUBLE)                    :: PSH(ELGP)               ! Output from subr SHP3DP. Shape fcn at Gauss pts SSI, SSJ
       REAL(DOUBLE)                    :: SIGxx                   ! Normal stress in the elem x  direction
       REAL(DOUBLE)                    :: SIGyy                   ! Normal stress in the elem y  direction
@@ -126,7 +126,7 @@
       REAL(DOUBLE)                    :: TGAUSS(1,NTSUB)         ! Temp at a Gauss point for a theral subcase
       REAL(DOUBLE)                    :: VOLUME                  ! 3D element volume
       REAL(DOUBLE)                    :: SSI,SSJ,SSK             ! Isoparametric coordinates of a point.
-
+      REAL(DOUBLE)                    :: M_1DOF(ELGP,ELGP)      ! Consistent mass matrix with 1 DOF per node.
  
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN
@@ -205,14 +205,28 @@
  
       IF (OPT(1) == 'Y') THEN
 
-         M0 = (RHO(1))*VOLUME/ELGP
+         ! Consistent mass matrix
+         ! ME = ∫ N' ρ N det(J) dv
 
-         DO I=1,ELGP
-            DO J=1,3
-               K = 6*(I-1) + J
-               ME(K,K) = M0
+         M_1DOF(:,:) = ZERO
+         GAUSS_PT = 0
+         DO K=1,IORD_K
+            DO IJ=1,IORD_IJ
+               GAUSS_PT = GAUSS_PT + 1
+
+               CALL SHP3DP ( I, J, K, ELGP, SUBR_NAME, IORD_MSG, IORD_IJ, IORD_K, SS_I(IJ), SS_J(IJ), SS_K(K), 'N', PSH, DPSHG )
+               INTFAC = DETJ(GAUSS_PT)*HH_IJ(IJ)*HH_K(K)
+
+               DO L=1,ELGP
+                  DO M=1,ELGP
+                     M_1DOF(L,M) = M_1DOF(L,M) + PSH(L) * PSH(M) * RHO(1) * INTFAC
+                  ENDDO
+               ENDDO
             ENDDO
          ENDDO
+
+
+         CALL LUMP_MASS( M_1DOF )
 
       ENDIF
 

--- a/Source/EMG/EMG5/TETRA.f90
+++ b/Source/EMG/EMG5/TETRA.f90
@@ -40,7 +40,7 @@
       USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, F06
       USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR, MAX_ORDER_TETRA, NTSUB
       USE TIMDAT, ONLY                :  TSEC
-      USE CONSTANTS_1, ONLY           :  HALF, QUARTER, ZERO, FOUR
+      USE CONSTANTS_1, ONLY           :  HALF, QUARTER, ZERO
       USE DEBUG_PARAMETERS, ONLY      :  DEBUG
       USE SUBR_BEGEND_LEVELS, ONLY    :  TETRA_BEGEND
       USE NONLINEAR_PARAMS, ONLY      :  LOAD_ISTEP
@@ -49,6 +49,7 @@
                                          SE1, SE2, STE1, STRESS, TREF, TYPE
  
       USE TETRA_USE_IFs
+      USE LUMP_MASS_Interface
 
       IMPLICIT NONE 
   
@@ -100,7 +101,6 @@
       REAL(DOUBLE)                    :: JAC(3,3)                ! An output from subr JAC3D, called herein. 3 x 3 Jacobian matrix.
       REAL(DOUBLE)                    :: JACI(3,3)               ! An output from subr JAC3D, called herein. 3 x 3 Jacobian inverse.
       REAL(DOUBLE)                    :: KWW(3,3)                ! Portion of differential stiffness matrix
-      REAL(DOUBLE)                    :: M0                      ! An intermediate variable used in calc elem mass, ME
       REAL(DOUBLE)                    :: PSH(ELGP)               ! Output from subr SHP3DT. Shape fcn at Gauss pts SSI, SSJ
       REAL(DOUBLE)                    :: SIGxx                   ! Normal stress in the elem x  direction
       REAL(DOUBLE)                    :: SIGyy                   ! Normal stress in the elem y  direction
@@ -117,7 +117,8 @@
       REAL(DOUBLE)                    :: TREF1                   ! TREF(1)
       REAL(DOUBLE)                    :: VOLUME                  ! 3D element volume
       REAL(DOUBLE)                    :: SSI,SSJ,SSK             ! Isoparametric coordinates of a point.
-      
+      REAL(DOUBLE)                    :: M_1DOF(ELGP,ELGP)      ! Consistent mass matrix with 1 DOF per node.
+            
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN
          CALL OURTIM
@@ -190,14 +191,26 @@
  
       IF (OPT(1) == 'Y') THEN
 
-         M0 = (RHO(1))*VOLUME/ELGP
+         ! Consistent mass matrix
+         ! ME = ∫ N' ρ N det(J) dv
 
-         DO I=1,ELGP
-            DO J=1,3
-               K = 6*(I-1) + J
-               ME(K,K) = M0
+         M_1DOF(:,:) = ZERO
+         GAUSS_PT = 0
+         DO I=1,IORD
+            GAUSS_PT = GAUSS_PT + 1
+
+            CALL SHP3DT ( I, ELGP, SUBR_NAME, IORD_MSG, IORD, SSS_I(I), SSS_J(I), SSS_K(I), 'N', PSH, DPSHG )
+            INTFAC = DETJ(I)*HHH_IJK(I)
+
+            DO L=1,ELGP
+               DO M=1,ELGP
+                  M_1DOF(L,M) = M_1DOF(L,M) + PSH(L) * PSH(M) * RHO(1) * INTFAC
+               ENDDO
             ENDDO
          ENDDO
+
+
+         CALL LUMP_MASS( M_1DOF )
 
       ENDIF
 

--- a/Source/EMG/LUMP_MASS.f90
+++ b/Source/EMG/LUMP_MASS.f90
@@ -1,0 +1,75 @@
+! #################################################################################################################################
+! Begin MIT license text.                                                                                    
+! _______________________________________________________________________________________________________
+                                                                                                         
+! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)                                              
+                                                                                                         
+! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and      
+! associated documentation files (the "Software"), to deal in the Software without restriction, including
+! without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to   
+! the following conditions:                                                                              
+                                                                                                         
+! The above copyright notice and this permission notice shall be included in all copies or substantial   
+! portions of the Software and documentation.                                                                              
+                                                                                                         
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS                                
+! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                            
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                            
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                                 
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                          
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                              
+! THE SOFTWARE.                                                                                          
+! _______________________________________________________________________________________________________
+                                                                                                        
+! End MIT license text.                                                                                      
+      SUBROUTINE LUMP_MASS ( M_1DOF )
+
+! Converts a consistent mass matrix with one row and column per node to a lumped (diagonal) mass matrix
+! with values duplicated on each of the 3 translational DOFs.
+
+      USE PENTIUM_II_KIND, ONLY       :  DOUBLE, LONG
+      USE MODEL_STUF, ONLY            :  ELGP, ME
+      USE CONSTANTS_1, ONLY           :  ZERO
+
+      IMPLICIT NONE 
+
+      INTEGER(LONG)                   :: I,J,L
+      INTEGER(LONG)                   :: KI, KJ            ! For converting grid point number to element DOF number
+
+      REAL(DOUBLE), INTENT(INOUT)     :: M_1DOF(ELGP,ELGP)
+      REAL(DOUBLE)                    :: ROW_SUM
+
+
+! **********************************************************************************************************************************
+
+      ! Row sum to convert consistent to lumped mass matrix
+      DO I=1,ELGP
+         ROW_SUM = ZERO
+         DO J=1,ELGP
+            ROW_SUM = ROW_SUM + M_1DOF(I,J)
+            M_1DOF(I,J) = ZERO
+         ENDDO
+         M_1DOF(I,I) = ROW_SUM
+      ENDDO
+
+
+      ME(:,:) = ZERO
+
+                                                           ! Copy to all 3 translational DOFs of each node.
+      DO I=1,ELGP
+         DO J=1,ELGP
+            KI = (I-1) * 6
+            KJ = (J-1) * 6
+            DO L=1,3
+               ME(KI + L, KJ + L) = M_1DOF(I,J)
+            ENDDO
+         ENDDO
+      ENDDO
+
+      RETURN
+
+
+! **********************************************************************************************************************************
+  
+      END SUBROUTINE LUMP_MASS

--- a/Source/Interfaces/LUMP_MASS_Interface.f90
+++ b/Source/Interfaces/LUMP_MASS_Interface.f90
@@ -1,0 +1,45 @@
+! ###############################################################################################################################
+! Begin MIT license text.                                                                                    
+! _______________________________________________________________________________________________________
+                                                                                                         
+! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)                                              
+                                                                                                         
+! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and      
+! associated documentation files (the "Software"), to deal in the Software without restriction, including
+! without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to   
+! the following conditions:                                                                              
+                                                                                                         
+! The above copyright notice and this permission notice shall be included in all copies or substantial   
+! portions of the Software and documentation.                                                                              
+                                                                                                         
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS                                
+! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                            
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                            
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                                 
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                          
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                              
+! THE SOFTWARE.                                                                                          
+! _______________________________________________________________________________________________________
+                                                                                                      
+! End MIT license text.                                                                                      
+
+   MODULE LUMP_MASS_Interface
+
+   INTERFACE
+
+      SUBROUTINE LUMP_MASS ( M_1DOF )
+
+      USE PENTIUM_II_KIND, ONLY       :  DOUBLE
+      USE MODEL_STUF, ONLY            :  ELGP
+
+      IMPLICIT NONE 
+
+      REAL(DOUBLE), INTENT(INOUT)     :: M_1DOF(ELGP,ELGP)
+
+      END SUBROUTINE LUMP_MASS
+
+   END INTERFACE
+
+   END MODULE LUMP_MASS_Interface
+


### PR DESCRIPTION
Fixes issue https://github.com/MYSTRANsolver/MYSTRAN/issues/94

Makes gravity load more uniform for:
CHEXA
CPENTA
CTETRA

Mass used to be divided equally between nodes, or corner nodes only on CHEXA. With this PR, they are integrated properly to make a consistent mass matrix then converted to lumped (diagonal) in case they need to be diagonal for some reason.