### PR TITLE
converted internal grid number to sequence number

### DIFF
--- a/Source/LK1/L1D/GET_GRID_6X6_MASS.f90
+++ b/Source/LK1/L1D/GET_GRID_6X6_MASS.f90
@@ -37,6 +37,7 @@
       USE CONSTANTS_1, ONLY           :  ZERO
       USE DOF_TABLES, ONLY            :  TDOF
       USE SPARSE_MATRICES, ONLY       :  I2_MGG, J_MGG, MGG
+      USE MODEL_STUF, ONLY            :  GRID_SEQ
  
       USE GET_GRID_6X6_MASS_USE_IFs
 
@@ -85,7 +86,7 @@
          ENDDO
       ENDDO
 
-      IGRID_DOF_NUM = 6*(IGRID - 1) + 1
+      IGRID_DOF_NUM = 6*(GRID_SEQ(IGRID) - 1) + 1
 k_do: DO K=1,NTERM_MGG
 
          IF ((I2_MGG(K) >= IGRID_DOF_NUM) .AND. (I2_MGG(K) <= IGRID_DOF_NUM + 5)) THEN

--- a/Source/LK1/L1E/MGGC_MASS_MATRIX.f90
+++ b/Source/LK1/L1E/MGGC_MASS_MATRIX.f90
@@ -84,8 +84,7 @@
       IROW_START = 1
 i_do1:DO I=1,NGRID
 
-!xx      GRID_NUM = GRID_ID(INV_GRID_SEQ(I))               ! GRID_NUM's are in TDOFI order (internal DOF order)
-         GRID_NUM = GRID_ID(I)
+         GRID_NUM = GRID_ID(INV_GRID_SEQ(I))               ! GRID_NUM's are in TDOFI order (internal DOF order)
          CALL MGG_CONM2_PROC ( I, GRID_NUM, MGG_CONM2, MGG_CONM2_NONZERO )
          CALL GET_GRID_NUM_COMPS ( GRID_NUM, NUM_COMPS, SUBR_NAME )
 


### PR DESCRIPTION
Fixes #150

Mass matrix MGG is ordered by grid point sequence numbers, not internal grid point numbers so we have to look up the sequence number before indexing MGG.

I also reverted an old edit for CONM2 which was putting point mass into the mass matrix in internal grid point order instead of grid sequence order. The effect of that cancelled out the use of internal grid point order in GET_GRID_6X6_MASS.

Now both element density and concentrated mass work correctly when the grid point order in the input file (grid sequence order) is different from the ID numbering order.
