### PR TITLE
Increased granularity of progress counter from 1% to 10%

### DIFF
--- a/Source/UTIL/COUNTER_PROGRESS.f90
+++ b/Source/UTIL/COUNTER_PROGRESS.f90
@@ -55,8 +55,8 @@ SUBROUTINE COUNTER_PROGRESS(NEW_VALUE)
       RETURN
    END IF
 
-   ! Compute the new percentage
-   NEW_PERC = FLOOR(100.0 * NEW_VALUE / COUNTER_TOTAL)
+   ! Compute the new percentage in increments of 10%
+   NEW_PERC = FLOOR(10.0 * NEW_VALUE / COUNTER_TOTAL) * 10
    
 
    ! Check if there has been a change, or if the amount is zero


### PR DESCRIPTION
Reduces the quantity of output messages which helps performance in Mecway.

Now that the solver is much faster, no stage should be so slow that you're wondering if it's crashed waiting for 10% of something, so I think this is fine for everyone. Almost everything that uses progress counter whizzes from 0% to 100% in the blink of an eye anyway.