### PR TITLE
Small counters update

### DIFF
--- a/Source/Modules/SCONTR.f90
+++ b/Source/Modules/SCONTR.f90
@@ -1,28 +1,28 @@
 ! ##################################################################################################################################
-! Begin MIT license text.                                                                                    
+! Begin MIT license text.
 ! _______________________________________________________________________________________________________
-                                                                                                         
-! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)                                              
-                                                                                                         
-! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and      
+
+! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 ! associated documentation files (the "Software"), to deal in the Software without restriction, including
 ! without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to   
-! the following conditions:                                                                              
-                                                                                                         
-! The above copyright notice and this permission notice shall be included in all copies or substantial   
-! portions of the Software and documentation.                                                                              
-                                                                                                         
-! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS                                
-! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                            
-! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                            
-! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                                 
-! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                          
-! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                              
-! THE SOFTWARE.                                                                                          
+! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to
+! the following conditions:
+
+! The above copyright notice and this permission notice shall be included in all copies or substantial
+! portions of the Software and documentation.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
 ! _______________________________________________________________________________________________________
-                                                                                                        
-! End MIT license text.                                                                                      
+
+! End MIT license text.
 
       MODULE SCONTR
 
@@ -30,17 +30,17 @@
 
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, SINGLE, DOUBLE
       USE CONSTANTS_1, ONLY           :  ZERO
-  
+
       IMPLICIT NONE
 
       SAVE
 
       INTEGER(LONG), PRIVATE   :: I                         ! Only use is in implied DO loops below to initialize variables
- 
+
       INTEGER(LONG), PARAMETER :: NCCCD                  = 31                ! Max number of words in array CC_CMD_DESCRIBERS
 
 ! System control / counters
-  
+
       CHARACTER(  7*BYTE), PARAMETER :: PROG_NAME        = 'MYSTRAN'         ! This computer program's name
       CHARACTER( 31*BYTE), PARAMETER :: BLNK_SUB_NAM     = ' '               ! Blank subr name
 
@@ -54,17 +54,17 @@
       CHARACTER(  1*BYTE)            :: ELESORT_RUN      = 'N'               ! 'Y'/'N' indicator of whether subr ELESORT has run
       CHARACTER(  1*BYTE)            :: EPSIL1_SET       = 'N'               ! 'Y'/'N' indicator of whether EPSIL(1) is in B.D. deck
       CHARACTER(  6*BYTE)            :: ENFORCED         = 'N'               ! If 'Y' then this is a run where all DOF's are SE-set
-      CHARACTER(  5*BYTE)            :: FACTORED_MATRIX  = 'none '           ! Name of matrix that has been decomposed into 
+      CHARACTER(  5*BYTE)            :: FACTORED_MATRIX  = 'none '           ! Name of matrix that has been decomposed into
 !                                                                              triangular factors (e.g.'KLL  ')
-      CHARACTER(  1*BYTE)            :: IERRFL(10)       = (/('N', I=1,10)/) ! 'Y', 'N' indicates errs in Bulk Data card fields 
-      CHARACTER(  1*BYTE)            :: IMB_BLANK(2:9)   = (/('N', I=2, 9)/) ! 'Y', 'N' indicates imbedded blanks in B.D. field 
+      CHARACTER(  1*BYTE)            :: IERRFL(10)       = (/('N', I=1,10)/) ! 'Y', 'N' indicates errs in Bulk Data card fields
+      CHARACTER(  1*BYTE)            :: IMB_BLANK(2:9)   = (/('N', I=2, 9)/) ! 'Y', 'N' indicates imbedded blanks in B.D. field
       CHARACTER(  1*BYTE)            :: PRINTENV         = 'N'               ! 'Y' if Software Passport env vars are to be printed
       CHARACTER(  1*BYTE)            :: RESTART          = 'N'               ! 'Y' if run is a restart
       CHARACTER( 16*BYTE)            :: SOL_NAME         = '                '! Name for the solution (e.g. 'STATICS')
       CHARACTER( 2*BYTE)             :: TSET_CHR_LEN     = '  '              ! Char len of entries in TSET
 
       CHARACTER(  1*BYTE)            :: UNLOCK           = 'N'               ! Y or N indicator for whether program will run
-!                                                                              unlimited size problems 
+!                                                                              unlimited size problems
       INTEGER(LONG)            :: IBIT(0:15)          = (/(2**I, I=0,15)/)
       INTEGER(LONG)            :: JF(10)              = (/(   I, I=1,10)/)
 
@@ -77,12 +77,12 @@
       INTEGER(LONG), PARAMETER :: MAX_INTEGER_LEN     =  10      ! Max number of digits in any integer to keep integers <= 4 bytes
       INTEGER(LONG), PARAMETER :: NUM_TRIA_ORDERS     =   3      ! Num of triangular integration orders for isoparametric elems
 
-      INTEGER(LONG)            :: BANDIT_ERR          =   0      ! Error report from Bandit    
+      INTEGER(LONG)            :: BANDIT_ERR          =   0      ! Error report from Bandit
       INTEGER(LONG)            :: DEMO_GRID_LIMIT     =  10      ! Max number of grids allowed in demo ver of the program
       INTEGER(LONG)            :: FATAL_ERR           =   0      ! Fatal err count from input (Exec & Case Control, Bulk Data)
-      INTEGER(LONG)            :: WARN_ERR            =   0      ! Warn err count from input (Exec & Case Control, Bulk Data) 
+      INTEGER(LONG)            :: WARN_ERR            =   0      ! Warn err count from input (Exec & Case Control, Bulk Data)
 
-      INTEGER(LONG)            :: INT_SC_NUM          =   0      ! Internal subcase number 
+      INTEGER(LONG)            :: INT_SC_NUM          =   0      ! Internal subcase number
       INTEGER(LONG)            :: JTSUB               =   0      ! Internal thermal array col no. corresponding to INT_SC_NUM
 
       INTEGER(LONG)            :: KLL_SDIA            =   0      ! Number of super-diagonals in matrix KLL
@@ -90,19 +90,19 @@
       INTEGER(LONG)            :: KMSM_SDIA           =   0      ! Number of super-diagonals in matrix KMSM
       INTEGER(LONG)            :: KOO_SDIA            =   0      ! Number of super-diagonals in matrix KOO
       INTEGER(LONG)            :: KRRcb_SDIA          =   0      ! Number of super-diagonals in matrix KRRcb
- 
+
       INTEGER(LONG)            :: KMAT_BW             =   0      ! 6 times grid BW returned from subr BANDIT called in subr LINK1
 
-      INTEGER(LONG)            :: LINKNO              =   0      ! LINK num being run 
+      INTEGER(LONG)            :: LINKNO              =   0      ! LINK num being run
       INTEGER(LONG)            :: LINKNO_L1A          =   0      ! LINK num MYSTRAN was executing when file LINK1A was written
       INTEGER(LONG)            :: LINKNO_START        =   0      ! LINK num to start MYSTRAN with. Normally this is LINK 1
 !                                                                  however, if the program was terminated abnormally right as
 !                                                                  a new LINK is beginning, this allows a "restart"
- 
+
       INTEGER(LONG)            :: LBAROFF             =   0      ! Max allow num of CBAR, CBEAM offset vectors      (see note (1))
       INTEGER(LONG)            :: LBUSHOFF            =   0      ! Max allow num of CBUSH       offset vectors      (see note (1))
-      INTEGER(LONG)            :: LCMASS              =   0      ! Max allow num of CMASSi Bulk Data cards   (see note (1)) 
-      INTEGER(LONG)            :: LCONM2              =   0      ! Max allow num of CONM2  Bulk Data cards   (see note (1)) 
+      INTEGER(LONG)            :: LCMASS              =   0      ! Max allow num of CMASSi Bulk Data cards   (see note (1))
+      INTEGER(LONG)            :: LCONM2              =   0      ! Max allow num of CONM2  Bulk Data cards   (see note (1))
       INTEGER(LONG)            :: LCORD               =   0      ! Max allow num of CORD   Bulk Data cards   (see note (1))
       INTEGER(LONG)            :: LDOFG               =   0      ! Max allow num of G-set DOF's (checked against NDOFG)
       INTEGER(LONG)            :: LEDAT               =   0      ! Max allow num of element connection data  (see note (1))
@@ -114,7 +114,7 @@
       INTEGER(LONG)            :: LIND_GRDS_MPCS      =   0      ! Max allow num of independent grids on MPC's and rigid elems
       INTEGER(LONG)            :: LLOADC              =   0      ! Max no. of pairs of (load fac/load mag) over all LOAD B.D. cards
 !                                                                  incl the pair defined by the LOAD card set ID and overall scale
-!                                                                  factor. Counted  by subr LOADB0 based on info from subr BD_LOAD0 
+!                                                                  factor. Counted  by subr LOADB0 based on info from subr BD_LOAD0
       INTEGER(LONG)            :: LLOADR              =   0      ! Max allow num of LOAD    Bulk Data cards   (see note (1))
       INTEGER(LONG)            :: LMATANGLE           =   0      ! Max allow num of plate elem matl angles    (see note (1))
       INTEGER(LONG)            :: LMATL               =   0      ! Max allow num of matl    Bulk Data cards   (see note (1))
@@ -128,7 +128,7 @@
       INTEGER(LONG)            :: LPBUSH              =   0      ! Max allow num of PBUSH   Bulk Data cards   (see note (1))
       INTEGER(LONG)            :: LPCOMP              =   0      ! Max allow num of PCOMP   Bulk Data cards   (see note (1))
       INTEGER(LONG)            :: LPCOMP_PLIES        =   0      ! Max allow num of plies for any PCOMP entry
-      INTEGER(LONG)            :: LPDAT               =   0      ! Max allow num of rows for array PDATA 
+      INTEGER(LONG)            :: LPDAT               =   0      ! Max allow num of rows for array PDATA
       INTEGER(LONG)            :: LPELAS              =   0      ! Max allow num of PELAS   Bulk Data cards   (see note (1))
       INTEGER(LONG)            :: LPLATEOFF           =   0      ! Max allow num of plate elem offsets        (see note (1))
       INTEGER(LONG)            :: LPLATETHICK         =   0      ! Max allow num of plate elem thicknesses    (see note (1))
@@ -143,8 +143,8 @@
       INTEGER(LONG)            :: LPUSERIN            =   0      ! Max allow num of PUSERIN Bulk Data cards   (see note (1))
       INTEGER(LONG)            :: LRFORCE             =   0      ! Max allow num of RFORCE  Bulk data entries (see note (1))
       INTEGER(LONG)            :: LRIGEL              =   0      ! Max allow num of rigid elems           (see note (1))
-      INTEGER(LONG)            :: LSEQ                =   0      ! Max allow num of rows for arrays SEQ1, SEQ2 
-      INTEGER(LONG)            :: LSETLN              =   0      ! Max allow num of chars in SET definitions (see Note (1)) 
+      INTEGER(LONG)            :: LSEQ                =   0      ! Max allow num of rows for arrays SEQ1, SEQ2
+      INTEGER(LONG)            :: LSETLN              =   0      ! Max allow num of chars in SET definitions (see Note (1))
       INTEGER(LONG)            :: LSETS               =   0      ! Max allow num of Case Control SET's       (see Note (1))
       INTEGER(LONG)            :: LSLOAD              =   0      ! Max allow num of SLOAD pairs              (see Note (1))
       INTEGER(LONG)            :: LSNORM              =   0      ! Max allow num of SNORM Bulk Data cards    (see Note (1))
@@ -159,7 +159,7 @@
       INTEGER(LONG)            :: LTERM_KGG           =   0      ! Max allow num of terms in matrix KGG      (see note (1))
       INTEGER(LONG)            :: LTERM_KGGD          =   0      ! Max allow num of terms in matrix KGGD     (see note (1))
       INTEGER(LONG)            :: LTERM_MGGE          =   0      ! Max allow num of terms in matrix MGG for elems (see note (1))
-      INTEGER(LONG)            :: LVVEC               =   0      ! Max allow num of v vectors (CBAR)         (see Note (1)) 
+      INTEGER(LONG)            :: LVVEC               =   0      ! Max allow num of v vectors (CBAR)         (see Note (1))
 
       INTEGER(LONG)            :: MAX_ELEM_DEGREE     =   0      ! Max number of elements connected to any one grid
       INTEGER(LONG)            :: MAX_GAUSS_POINTS    =   0      ! Max number of Gauss pts for any element
@@ -213,54 +213,54 @@
       INTEGER(LONG)            :: NCUSER1             =   0      ! Count of no. of CUSER1  elems
       INTEGER(LONG)            :: NCUSERIN            =   0      ! Count of no. of CUSERIN elems
 
-      INTEGER(LONG)            :: NDOFA               =   0      ! Count of no. of DOF's in the A-set  
+      INTEGER(LONG)            :: NDOFA               =   0      ! Count of no. of DOF's in the A-set
       INTEGER(LONG)            :: NDOF_EIG            =   0      ! DOF size to replace NDOFL for eigprob to avoid zero mass modes
-      INTEGER(LONG)            :: NDOFF               =   0      ! Count of no. of DOF's in the F-set  
-      INTEGER(LONG)            :: NDOFG               =   0      ! Count of no. of DOF's in the G-set 
-      INTEGER(LONG)            :: NDOFL               =   0      ! Count of no. of DOF's in the L-set  
-      INTEGER(LONG)            :: NDOFM               =   0      ! Count of no. of DOF's in the M-set  
-      INTEGER(LONG)            :: NDOFN               =   0      ! Count of no. of DOF's in the N-set  
-      INTEGER(LONG)            :: NDOFO               =   0      ! Count of no. of DOF's in the O-set  
-      INTEGER(LONG)            :: NDOFR               =   0      ! Count of no. of DOF's in the R-set  
-      INTEGER(LONG)            :: NDOFS               =   0      ! Count of no. of DOF's in the S-set  
+      INTEGER(LONG)            :: NDOFF               =   0      ! Count of no. of DOF's in the F-set
+      INTEGER(LONG)            :: NDOFG               =   0      ! Count of no. of DOF's in the G-set
+      INTEGER(LONG)            :: NDOFL               =   0      ! Count of no. of DOF's in the L-set
+      INTEGER(LONG)            :: NDOFM               =   0      ! Count of no. of DOF's in the M-set
+      INTEGER(LONG)            :: NDOFN               =   0      ! Count of no. of DOF's in the N-set
+      INTEGER(LONG)            :: NDOFO               =   0      ! Count of no. of DOF's in the O-set
+      INTEGER(LONG)            :: NDOFR               =   0      ! Count of no. of DOF's in the R-set
+      INTEGER(LONG)            :: NDOFS               =   0      ! Count of no. of DOF's in the S-set
       INTEGER(LONG)            :: NDOFSA              =   0      ! Count of no. of DOF's in the S-set constr to 0 via AUTOSPC
-      INTEGER(LONG)            :: NDOFSB              =   0      ! Count of no. of DOF's in the S-set constr to 0 on SPC/SPC1 cards 
-      INTEGER(LONG)            :: NDOFSE              =   0      ! Count of no. of DOF's in the S-set with enforced displacement 
+      INTEGER(LONG)            :: NDOFSB              =   0      ! Count of no. of DOF's in the S-set constr to 0 on SPC/SPC1 cards
+      INTEGER(LONG)            :: NDOFSE              =   0      ! Count of no. of DOF's in the S-set with enforced displacement
       INTEGER(LONG)            :: NDOFSG              =   0      ! Count of no. of DOF's in the S-set perm SPC'd on GRID cards
       INTEGER(LONG)            :: NDOFSZ              =   0      ! NDOFSB + NDOFSG Count of no. of DOF's in the S-set with 0 displ
 
       INTEGER(LONG)            :: NEDAT               =   0      ! Count of no. of terms in EDAT array
       INTEGER(LONG)            :: NELE                =   0      ! Count of no. of elastic elems
       INTEGER(LONG)            :: NFORCE              =   0      ! Count of no. of FORCE/MOMENT Bulk Data cards
-      INTEGER(LONG)            :: NGRAV               =   0      ! Count of no. of GRAV    Bulk Data cards 
-      INTEGER(LONG)            :: NGRDSET             =   0      ! Count of no. of GRDSET  Bulk Data cards 
-      INTEGER(LONG)            :: NGRID               =   0      ! Count of no. of GRID    Bulk Data cards 
+      INTEGER(LONG)            :: NGRAV               =   0      ! Count of no. of GRAV    Bulk Data cards
+      INTEGER(LONG)            :: NGRDSET             =   0      ! Count of no. of GRDSET  Bulk Data cards
+      INTEGER(LONG)            :: NGRID               =   0      ! Count of no. of GRID    Bulk Data cards
       INTEGER(LONG)            :: NIND_GRDS_MPCS      =   0      ! Count of no. of independent grids on MPC's and rigid elems
-      INTEGER(LONG)            :: NLOAD               =   0      ! Count of no. of LOAD    Bulk Data cards 
+      INTEGER(LONG)            :: NLOAD               =   0      ! Count of no. of LOAD    Bulk Data cards
       INTEGER(LONG)            :: NMATANGLE           =   0      ! Count of no. of matl property angles on plate elem conn entries
-      INTEGER(LONG)            :: NMATL               =   0      ! Count of no. of matl    Bulk Data cards 
-      INTEGER(LONG)            :: NMPC                =   0      ! Count of no. of MPC     Bulk Data cards 
+      INTEGER(LONG)            :: NMATL               =   0      ! Count of no. of matl    Bulk Data cards
+      INTEGER(LONG)            :: NMPC                =   0      ! Count of no. of MPC     Bulk Data cards
       INTEGER(LONG)            :: NMPCADD             =   0      ! Count of no. of MPCADD cards
-      INTEGER(LONG)            :: NPBAR               =   0      ! Count of no. of PBAR    Bulk Data cards 
-      INTEGER(LONG)            :: NPBARL              =   0      ! Count of no. of PBARL   Bulk Data cards 
-      INTEGER(LONG)            :: NPBEAM              =   0      ! Count of no. of PBEAM   Bulk Data cards 
-      INTEGER(LONG)            :: NPBUSH              =   0      ! Count of no. of PBUSH   Bulk Data cards 
-      INTEGER(LONG)            :: NPCARD              =   0      ! Count of no. of PLOAD1, PLOAD2 cards written to filename.L1Q 
-      INTEGER(LONG)            :: NPCOMP              =   0      ! Count of no. of PCOMP   Bulk Data cards 
+      INTEGER(LONG)            :: NPBAR               =   0      ! Count of no. of PBAR    Bulk Data cards
+      INTEGER(LONG)            :: NPBARL              =   0      ! Count of no. of PBARL   Bulk Data cards
+      INTEGER(LONG)            :: NPBEAM              =   0      ! Count of no. of PBEAM   Bulk Data cards
+      INTEGER(LONG)            :: NPBUSH              =   0      ! Count of no. of PBUSH   Bulk Data cards
+      INTEGER(LONG)            :: NPCARD              =   0      ! Count of no. of PLOAD1, PLOAD2 cards written to filename.L1Q
+      INTEGER(LONG)            :: NPCOMP              =   0      ! Count of no. of PCOMP   Bulk Data cards
       INTEGER(LONG)            :: NPDAT               =   0      ! Count of no. of rows that go into array PDATA
-      INTEGER(LONG)            :: NPELAS              =   0      ! Count of no. of PELAS  Bulk Data cards 
+      INTEGER(LONG)            :: NPELAS              =   0      ! Count of no. of PELAS  Bulk Data cards
       INTEGER(LONG)            :: NPLATEOFF           =   0      ! Count of no. of plate element offsets on plate elem conn entries
       INTEGER(LONG)            :: NPLATETHICK         =   0      ! Count of no. of plate thicknesses on plate elem conn entries
       INTEGER(LONG)            :: NPLOTEL             =   0      ! Count of no. of PLOTEL
-      INTEGER(LONG)            :: NPLOAD              =   0      ! Count of no. of PLOADi  Bulk Data cards 
+      INTEGER(LONG)            :: NPLOAD              =   0      ! Count of no. of PLOADi  Bulk Data cards
       INTEGER(LONG)            :: NPLOAD4_3D          =   0      ! Count of no. of PLOAD4 entries that are for solid elements
-      INTEGER(LONG)            :: NPMASS              =   0      ! Count of no. of PMASS  Bulk Data cards 
-      INTEGER(LONG)            :: NPROD               =   0      ! Count of no. of PROD   Bulk Data cards 
+      INTEGER(LONG)            :: NPMASS              =   0      ! Count of no. of PMASS  Bulk Data cards
+      INTEGER(LONG)            :: NPROD               =   0      ! Count of no. of PROD   Bulk Data cards
       INTEGER(LONG)            :: NPSHEAR             =   0      ! Count of no. of PSHEAR Bulk Data cards
-      INTEGER(LONG)            :: NPSHEL              =   0      ! Count of no. of PSHELL Bulk Data cards 
-      INTEGER(LONG)            :: NPSOLID             =   0      ! Count of no. of PSOLID Bulk Data cards 
-      INTEGER(LONG)            :: NPUSER1             =   0      ! Count of no. of PUSER1 Bulk Data cards 
-      INTEGER(LONG)            :: NPUSERIN            =   0      ! Count of no. of PUSER1 Bulk Data cards 
+      INTEGER(LONG)            :: NPSHEL              =   0      ! Count of no. of PSHELL Bulk Data cards
+      INTEGER(LONG)            :: NPSOLID             =   0      ! Count of no. of PSOLID Bulk Data cards
+      INTEGER(LONG)            :: NPUSER1             =   0      ! Count of no. of PUSER1 Bulk Data cards
+      INTEGER(LONG)            :: NPUSERIN            =   0      ! Count of no. of PUSER1 Bulk Data cards
       INTEGER(LONG)            :: NRBAR               =   0      ! Count of no. of RBAR rigid elems
       INTEGER(LONG)            :: NRBE1               =   0      ! Count of no. of RBE1 rigid elems
       INTEGER(LONG)            :: NRBE2               =   0      ! Count of no. of RBE2 rigid elems
@@ -284,18 +284,18 @@
       INTEGER(LONG)            :: NROWS_TXT_STRE      =   0      ! Num of rows for TXT
       INTEGER(LONG)            :: NROWS_TXT_STRN      =   0      ! Num of rows for TXT
       INTEGER(LONG)            :: NRSPLINE            =   0      ! Count of no. of RSPLINE elements
-      INTEGER(LONG)            :: NSEQ                =   0      ! Count of no. of grid points that are on SEQGP Bulk Data cards 
-      INTEGER(LONG)            :: NSETS               =   0      ! Count of no. of SET's in Case Control 
-      INTEGER(LONG)            :: NSLOAD              =   0      ! Count of no. of SLOAD pairs (point/mag) 
-      INTEGER(LONG)            :: NSNORM              =   0      ! Count of no. of SNORM Bulk Data cards 
-      INTEGER(LONG)            :: NSPC                =   0      ! Count of no. of SPC  cards written to filename.L1O 
-      INTEGER(LONG)            :: NSPC1               =   0      ! Count of no. of SPC1 cards written to filename.L1O 
+      INTEGER(LONG)            :: NSEQ                =   0      ! Count of no. of grid points that are on SEQGP Bulk Data cards
+      INTEGER(LONG)            :: NSETS               =   0      ! Count of no. of SET's in Case Control
+      INTEGER(LONG)            :: NSLOAD              =   0      ! Count of no. of SLOAD pairs (point/mag)
+      INTEGER(LONG)            :: NSNORM              =   0      ! Count of no. of SNORM Bulk Data cards
+      INTEGER(LONG)            :: NSPC                =   0      ! Count of no. of SPC  cards written to filename.L1O
+      INTEGER(LONG)            :: NSPC1               =   0      ! Count of no. of SPC1 cards written to filename.L1O
       INTEGER(LONG)            :: NSPCADD             =   0      ! Count of no. of SPCADD cards
       INTEGER(LONG)            :: NSPOINT             =   0      ! Count of no. of SPOINT's
       INTEGER(LONG)            :: NUM_SPCSIDS         =   0      ! The number of SPC set ID's called for in an execution
-      INTEGER(LONG)            :: NSUB                =   0      ! Count of no. of subcases  
+      INTEGER(LONG)            :: NSUB                =   0      ! Count of no. of subcases
       INTEGER(LONG)            :: NTCARD              =   0      ! Count of no. of TEMP/TEMPRB/TEMPP1 cards written to filename.L1K
-      INTEGER(LONG)            :: NTDAT               =   0      ! Count of no. of rows that go into array TDATA 
+      INTEGER(LONG)            :: NTDAT               =   0      ! Count of no. of rows that go into array TDATA
       INTEGER(LONG)            :: NTERM_ALL           =   0      ! Count of no. of terms in ALL             matrix
       INTEGER(LONG)            :: NTERM_CG_LTM        =   0      ! Count of no. of terms in CG_LDS_LTMcb    matrix
       INTEGER(LONG)            :: NTERM_DLR           =   0      ! Count of no. of terms in DLR             matrix
@@ -397,7 +397,7 @@
       INTEGER(LONG)            :: NTERM_RMN           =   0      ! Count of no. of terms in RMN             matrix
       INTEGER(LONG)            :: NTERM_ULL           =   0      ! Count of no. of terms in ULL             matrix
       INTEGER(LONG)            :: NTERM_ULLI          =   0      ! Count of no. of terms in ULLI            matrix
-      INTEGER(LONG)            :: NTSUB               =   0      ! Count of no. of subcases with a thermal load 
+      INTEGER(LONG)            :: NTSUB               =   0      ! Count of no. of subcases with a thermal load
       INTEGER(LONG)            :: NUM_CB_DOFS         =   0      ! Num of Craig-Bampton DOF's (2*NDOFR+NVEC)
       INTEGER(LONG)            :: NUM_EIGENS          =   0      ! Num of eigenvals calc'd (may be > NVEC)
       INTEGER(LONG)            :: NUM_KLLD_DIAG_ZEROS =   0      ! Num of zeros on the diagonal of the KLLD stiff matrix
@@ -417,14 +417,14 @@
       INTEGER(LONG)            :: NVVEC               =   0      ! Count of the no. of v vectors (CBAR)
       INTEGER(LONG)            :: PCH_LINE_NUM        =   0      ! Line number in PCH ("punch") file
       INTEGER(LONG)            :: SETLEN              =   0      ! Count of the number characters in SET definitions
-      INTEGER(LONG)            :: TRIA_ORDER_NUMS(NUM_TRIA_ORDERS) =    (/1,3,7/)    
+      INTEGER(LONG)            :: TRIA_ORDER_NUMS(NUM_TRIA_ORDERS) =    (/1,3,7/)
                                                                  ! Triangular isoparametric integration orders
 
-      INTEGER(LONG), PARAMETER :: DEDAT_Q4_MATANG_KEY =   6      ! Delta in EDAT for QUAD4 to get from EID to the matl angle key 
+      INTEGER(LONG), PARAMETER :: DEDAT_Q4_MATANG_KEY =   6      ! Delta in EDAT for QUAD4 to get from EID to the matl angle key
       INTEGER(LONG), PARAMETER :: DEDAT_Q4_POFFS_KEY  =   8      ! Delta in EDAT for QUAD4 to get from EID to the offset key
       INTEGER(LONG), PARAMETER :: DEDAT_Q4_SHELL_KEY  =   9      ! Delta in EDAT for QUAD4 to get from EID to the shell/pcomp key
       INTEGER(LONG), PARAMETER :: DEDAT_Q4_THICK_KEY  =  10      ! Delta in EDAT for QUAD4 to get from EID to the thickness key
-      INTEGER(LONG), PARAMETER :: DEDAT_T3_MATANG_KEY =   5      ! Delta in EDAT for TRIA3 to get from EID to the matl angle key 
+      INTEGER(LONG), PARAMETER :: DEDAT_T3_MATANG_KEY =   5      ! Delta in EDAT for TRIA3 to get from EID to the matl angle key
       INTEGER(LONG), PARAMETER :: DEDAT_T3_POFFS_KEY  =   7      ! Delta in EDAT for TRIA3 to get from EID to the offset key
       INTEGER(LONG), PARAMETER :: DEDAT_T3_SHELL_KEY  =   8      ! Delta in EDAT for TRIA3 to get from EID to the shell/pcomp key
       INTEGER(LONG), PARAMETER :: DEDAT_T3_THICK_KEY  =   9      ! Delta in EDAT for TRIA3 to get from EID to the thickness key
@@ -438,9 +438,9 @@
       INTEGER(LONG), PARAMETER :: MAX_ORDER_TRIA      =   7      ! Max order that can be used when subr ORDER_TRIA  is called
       INTEGER(LONG), PARAMETER :: MAX_TOKEN_LEN       =   8      ! Max length (chars) of tokens in SET's
       INTEGER(LONG), PARAMETER :: MBUG                =  10      ! No. of kinds BUG outputs (dimension of WRT_BUG)
-      INTEGER(LONG), PARAMETER :: MCMASS              =   7      ! No. cols allowed in dimensioning array CMASS 
-      INTEGER(LONG), PARAMETER :: MCONM2              =   3      ! No. cols allowed in dimensioning array CONM2 
-      INTEGER(LONG), PARAMETER :: MCORD               =   5      ! No. cols allowed in dimensioning array CORD 
+      INTEGER(LONG), PARAMETER :: MCMASS              =   7      ! No. cols allowed in dimensioning array CMASS
+      INTEGER(LONG), PARAMETER :: MCONM2              =   3      ! No. cols allowed in dimensioning array CONM2
+      INTEGER(LONG), PARAMETER :: MCORD               =   5      ! No. cols allowed in dimensioning array CORD
       INTEGER(LONG), PARAMETER :: MEDAT_CBAR          =   8      ! No. terms that go into EDAT array for CBAR   elems
       INTEGER(LONG), PARAMETER :: MEDAT_CBEAM         =   8      ! No. terms that go into EDAT array for CBEAM  elems
       INTEGER(LONG), PARAMETER :: MEDAT_CBUSH         =   9      ! No. terms that go into EDAT array for CBEAM  elems
@@ -482,8 +482,8 @@
       INTEGER(LONG), PARAMETER :: MMSPRNT             =   3      ! No. cols allowed in dimensioning array MSPRNT
       INTEGER(LONG), PARAMETER :: MOGEL               =  12      ! No. cols allowed in dimensioning array OGEL
       INTEGER(LONG), PARAMETER :: MPDAT_PLOAD1        =   2      ! No. pressures on PLOAD1 Bulk Data card
-      INTEGER(LONG), PARAMETER :: MPDAT_PLOAD2        =   1      ! No. pressures on PLOAD2 Bulk Data card 
-      INTEGER(LONG), PARAMETER :: MPDAT_PLOAD4        =   4      ! No. pressuresa on PLOAD4 Bulk Data card 
+      INTEGER(LONG), PARAMETER :: MPDAT_PLOAD2        =   1      ! No. pressures on PLOAD2 Bulk Data card
+      INTEGER(LONG), PARAMETER :: MPDAT_PLOAD4        =   4      ! No. pressuresa on PLOAD4 Bulk Data card
       INTEGER(LONG), PARAMETER :: MPBAR               =   3      ! No. cols allowed in dimensioning array PBAR
       INTEGER(LONG), PARAMETER :: MPBARLU             =   6      ! Max num of dec places in format for writing PBAR equivs of PBARL
       INTEGER(LONG), PARAMETER :: MPBEAM              =   4      ! No. cols allowed in dimensioning array PBEAM
@@ -500,8 +500,8 @@
       INTEGER(LONG), PARAMETER :: MPSOLID             =   6      ! No. cols allowed in dimensioning array PSOLID
       INTEGER(LONG), PARAMETER :: MPUSER1             =   2      ! No. cols allowed in dimensioning array PUSER1
       INTEGER(LONG), PARAMETER :: MPUSERIN            =   2      ! No. cols allowed in dimensioning array PUSERIN
-      INTEGER(LONG), PARAMETER :: MRCONM2             =  10      ! No. cols allowed in dimensioning array RCONM2 
-      INTEGER(LONG), PARAMETER :: MRCORD              =  12      ! No. cols allowed in dimensioning array RCORD 
+      INTEGER(LONG), PARAMETER :: MRCONM2             =  10      ! No. cols allowed in dimensioning array RCONM2
+      INTEGER(LONG), PARAMETER :: MRCORD              =  12      ! No. cols allowed in dimensioning array RCORD
       INTEGER(LONG), PARAMETER :: MRGRID              =   3      ! No. cols allowed in dimensioning array RGRID
       INTEGER(LONG), PARAMETER :: MRMATLC             =  30      ! No. cols allowed in dimensioning array RMATL
       INTEGER(LONG), PARAMETER :: MRSNORM             =   3      ! No. cols allowed in dimensioning array RSNORM
@@ -528,7 +528,7 @@
       INTEGER(LONG), PARAMETER :: MUSERIN_MAT_NAMES   =   4      ! No. cols allowed in dimensioning array USERIN_MAT_NAMES
 
 ! Parameters used to denote bit positions in subcase arrays GROUT, ELOUT and ELDT. Note: if any of these change here, the changes
-! must be reflected in subr SUBCASE_PROC which assumes the following assignments since it uses IBIT(J), J = 0, 1, 2... and not the 
+! must be reflected in subr SUBCASE_PROC which assumes the following assignments since it uses IBIT(J), J = 0, 1, 2... and not the
 ! named variables below. GROUT, ELOUT and ELDT all have 16 bits with the following ones used:
 
       INTEGER(LONG), PARAMETER :: GROUT_ACCE_BIT      =   5      ! Bit pos in OGROUT, GROUT for G.P. accel print requests
@@ -569,6 +569,8 @@
       INTEGER(LONG)            :: COUNTER_PERC        = ZERO     ! Current percentage of the counter.
       INTEGER(LONG)            :: COUNTER_TOTAL       = ZERO     ! Max value of the counter
       INTEGER(LONG)            :: COUNTER_STARTED     = ZERO     ! Timestamp of counter start
+      INTEGER(LONG)            :: COUNTER_UPDATED     = ZERO     ! Timestamp of counter update
+      INTEGER(LONG)            :: COUNTER_LIMITER     = ZERO     ! Counter updates this second
       CHARACTER(:), ALLOCATABLE :: COUNTER_PREFIX
       CHARACTER(LEN=20) :: COUNTER_FMT
 

--- a/Source/UTIL/COUNTER_PROGRESS.f90
+++ b/Source/UTIL/COUNTER_PROGRESS.f90
@@ -1,27 +1,27 @@
 ! ##################################################################################################################################
-! Begin MIT license text.                                                                                    
+! Begin MIT license text.
 ! _______________________________________________________________________________________________________
-                                                                                                         
-! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)                                              
-                                                                                                         
-! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and      
+
+! Copyright 2022 Dr William R Case, Jr (mystransolver@gmail.com)
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 ! associated documentation files (the "Software"), to deal in the Software without restriction, including
 ! without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to   
-! the following conditions:                                                                              
-                                                                                                         
-! The above copyright notice and this permission notice shall be included in all copies or substantial   
-! portions of the Software and documentation.                                                                              
-                                                                                                         
-! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS                                
-! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                            
-! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                            
-! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                                 
-! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,                          
-! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                              
-! THE SOFTWARE.                                                                                          
+! copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to
+! the following conditions:
+
+! The above copyright notice and this permission notice shall be included in all copies or substantial
+! portions of the Software and documentation.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+! OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
 ! _______________________________________________________________________________________________________
-                                                                                                        
+
 ! End MIT license text.
 
 ! This subroutine increases the progress of a counter by some amount.
@@ -30,40 +30,62 @@
 ! performance impact.
 
 ! Arguments:
-!   NEW_VALUE: the new value for the counter.
-SUBROUTINE COUNTER_PROGRESS(NEW_VALUE)
+!   NEW_VALUE_OR_NEGATIVE: the new value for the counter, or a negative for 100% (force-finish)
+SUBROUTINE COUNTER_PROGRESS(NEW_VALUE_OR_NEGATIVE)
 
    USE PENTIUM_II_KIND, ONLY : LONG, DOUBLE
    USE SCONTR, ONLY : COUNTER_VALUE, COUNTER_PERC, COUNTER_TOTAL, &
-                      COUNTER_STARTED, COUNTER_PREFIX, COUNTER_FMT
+                      COUNTER_STARTED, COUNTER_PREFIX, COUNTER_FMT, &
+                      COUNTER_UPDATED, COUNTER_LIMITER
    USE IOUNT1, ONLY : SC1
    USE CONSTANTS_1, ONLY : ZERO
    USE PARAMS, ONLY : NOCOUNTS
-                      
+
    USE COUNTER_PROGRESS_USE_IFs
 
    IMPLICIT NONE
 
-   INTEGER(LONG), INTENT(IN) :: NEW_VALUE
+   INTEGER(LONG), INTENT(IN) :: NEW_VALUE_OR_NEGATIVE
    INTEGER(LONG)             :: NEW_PERC, ETA, NEW_TIME, ELAPSED, &
                                 ETA_HOURS, ETA_MINS, ETA_SECS, &
-                                ELAPSED_HOURS, ELAPSED_MINS, ELAPSED_SECS
+                                ELAPSED_HOURS, ELAPSED_MINS, ELAPSED_SECS, &
+                                NEW_VALUE
    REAL(DOUBLE)              :: SPEED
+   LOGICAL                   :: FORCED_PRINT, PERC_CHANGED, TOO_MANY
 
    ! Do nothing if NOCOUNTS is set
    IF (NOCOUNTS == 'Y') THEN
       RETURN
    END IF
 
+   IF (NEW_VALUE_OR_NEGATIVE < 0) THEN
+      NEW_VALUE = COUNTER_TOTAL
+   ELSE
+      NEW_VALUE = NEW_VALUE_OR_NEGATIVE
+   END IF
+
    ! Compute the new percentage
    NEW_PERC = FLOOR(100.0 * NEW_VALUE / COUNTER_TOTAL)
-   
 
+   FORCED_PRINT = NEW_VALUE == 0 .OR. NEW_VALUE == COUNTER_TOTAL
+   PERC_CHANGED = NEW_PERC /= COUNTER_PERC
+   TOO_MANY = .FALSE.
    ! Check if there has been a change, or if the amount is zero
-   IF (NEW_VALUE == 0 .OR. NEW_PERC /= COUNTER_PERC .OR. NEW_VALUE == COUNTER_TOTAL) THEN
+   IF (FORCED_PRINT .OR. PERC_CHANGED) THEN
       ! Compute elapsed time, 0 means we're too fast
       CALL UNIX_TIME(NEW_TIME)
       ELAPSED = NEW_TIME - COUNTER_STARTED
+      ! Zero the counter limiter if the current second has changed
+      IF (COUNTER_UPDATED /= NEW_TIME) THEN
+         COUNTER_LIMITER = 0
+      END IF
+      ! Limit to two non-forced updates
+      TOO_MANY = COUNTER_LIMITER >= 1
+   END IF
+
+   IF (FORCED_PRINT .OR. (PERC_CHANGED .AND. .NOT. TOO_MANY)) THEN
+      COUNTER_LIMITER = COUNTER_LIMITER + 1
+      COUNTER_UPDATED = NEW_TIME
       ! Okay, percentage change. Let's do this.
       ! First, print the basic string.
       WRITE(SC1, 4000, ADVANCE="NO") CHAR(13)


### PR DESCRIPTION
I bring two updates to the counters system I developed a while ago.

First, we had an excess of writes. Counters write to the screen when the percentage is 0% or 100% (first and last writes) and whenever the percentage changes. That means that a sub-second counter will write 101lines of output. That's an issue when parsing output or when writing to non-TTY descriptors, such as files or pipes.

To alleviate that, I separated the counter updates into "forced" (the first and last ones) and "non-forced" (all the others, when the percentage merely changes). I then limited "non-forced" updates to one per second. Now, instantaneous counters will produce at most 3 lines of output (as opposed to 101) and longer ones will average one per second.

Second, we had some issues with counters not finishing. `CYCLE` and `EXIT` instructions can muddle up the count. One could just directly write the desired total to force a counter to finish up, but that's hacky. Instead, I made it so the input to `COUNTER_PROGRESS` is checked for sign. If negative, it'll force the new value to be the desired total.

Therefore, a "dodgy" loop can just call `COUNTER_PROGRESS(-1)` outside the loop, thus ensuring that the counter finishes properly and a crash does not happen when a new one is started.

I suggest developers use this feature only as needed. In all the counters I converted to this new system, I have never had to force a counter to finish. In fact, I have identified actual MYSTRAN bugs after poorly-planned loops failed to finish their associated counter... so I'd first make sure that's not the case before forcing a counter to finish. Even when there are `CYCLE`s, placing the `COUNTER_PROGRESS` call at the top does the trick. `EXIT`s are more complicated though, and might justify the usage of such a trick.

Finally, I'd like to thank @victorkemp for identifying these issues and helping me arrive at this solution!