### PR TITLE
Optimize matadd sss

### DIFF
--- a/Source/Interfaces/MATADD_SSS_Interface.f90
+++ b/Source/Interfaces/MATADD_SSS_Interface.f90
@@ -28,17 +28,14 @@
 
    INTERFACE
 
-      SUBROUTINE MATADD_SSS ( NROWS, MAT_A_NAME, NTERM_A, I_A, J_A, A, ALPHA, MAT_B_NAME, NTERM_B, I_B, J_B, B, BETA,  &
-
+      SUBROUTINE MATADD_SSS ( NROWS, MAT_A_NAME, NTERM_A, I_A, J_A, A, ALPHA,  &
+                                     MAT_B_NAME, NTERM_B, I_B, J_B, B, BETA,   &
                                      MAT_C_NAME, NTERM_C, I_C, J_C, C )
  
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, F06
       USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR
       USE TIMDAT, ONLY                :  TSEC
-      USE CONSTANTS_1, ONLY           :  ZERO
-      USE DEBUG_PARAMETERS, ONLY      :  DEBUG
-      USE SPARSE_ALG_ARRAYS, ONLY     :  LOGICAL_VEC, REAL_VEC
       USE SUBR_BEGEND_LEVELS, ONLY    :  MATADD_SSS_BEGEND
  
       IMPLICIT NONE
@@ -46,7 +43,6 @@
       CHARACTER(LEN=*), INTENT(IN)    :: MAT_A_NAME        ! Name of matrix A
       CHARACTER(LEN=*), INTENT(IN)    :: MAT_B_NAME        ! Name of matrix B
       CHARACTER(LEN=*), INTENT(IN)    :: MAT_C_NAME        ! Name of matrix C
-      CHARACTER( 2*BYTE)              :: ALG               ! Which algorithm is used in solving for the terms in a row of C
 
       INTEGER(LONG), INTENT(IN )      :: NROWS             ! Number of rows in input matrices A and B
       INTEGER(LONG), INTENT(IN )      :: NTERM_A           ! Number of nonzero terms in input matrix A

--- a/Source/Interfaces/MATADD_SSS_NTERM_Interface.f90
+++ b/Source/Interfaces/MATADD_SSS_NTERM_Interface.f90
@@ -28,17 +28,14 @@
 
    INTERFACE
 
-      SUBROUTINE MATADD_SSS_NTERM ( NROWS, MAT_A_NAME, NTERM_A, I_A, J_A, SYM_A, MAT_B_NAME, NTERM_B, I_B, J_B, SYM_B,             &
-
+      SUBROUTINE MATADD_SSS_NTERM ( NROWS, MAT_A_NAME, NTERM_A, I_A, J_A, SYM_A,             &
+                                           MAT_B_NAME, NTERM_B, I_B, J_B, SYM_B,             &
                                            MAT_C_NAME, NTERM_C )
  
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, F06
-      USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR, WARN_ERR
+      USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR
       USE TIMDAT, ONLY                :  TSEC
-      USE PARAMS, ONLY                :  SUPWARN
-      USE DEBUG_PARAMETERS, ONLY      :  DEBUG
-      USE SPARSE_ALG_ARRAYS, ONLY     :  LOGICAL_VEC
       USE SUBR_BEGEND_LEVELS, ONLY    :  MATADD_SSS_NTERM_BEGEND
  
       IMPLICIT NONE
@@ -48,7 +45,6 @@
       CHARACTER(LEN=*), INTENT(IN)    :: MAT_C_NAME        ! Name of matrix C
       CHARACTER(LEN=*), INTENT(IN)    :: SYM_A             ! Flag for whether matrix A is stored sym (terms on and above diag)
       CHARACTER(LEN=*), INTENT(IN)    :: SYM_B             ! Flag for whether matrix B is stored sym (terms on and above diag)
-      CHARACTER( 2*BYTE)              :: ALG               ! Which algorithm is used in solving for the terms in a row of C
 
       INTEGER(LONG), INTENT(IN )      :: NROWS             ! Number of rows in input matrices A and B
       INTEGER(LONG), INTENT(IN )      :: NTERM_A           ! Number of nonzero terms in input matrix A

--- a/Source/Modules/DEBUG_PARAMETERS.f90
+++ b/Source/Modules/DEBUG_PARAMETERS.f90
@@ -141,10 +141,6 @@
 !        DEBUG  67    Not used
 !        DEBUG  80  > 0 print LAPACK_S scale factors, in subr EQUILIBRATE, used to equilibrate the stiffness matrices
 
-!        DEBUG  81  = 1 print data from subr MATADD_SSS_NTERM
-!                     2 print data from subr MATADD_SSS
-!                     3 print data from both subrs
- 
 !        DEBUG  82  = 1 print data from subr MATMULT_SFF
 
 !        DEBUG  83  = 1 print data from subr MATMULT_SFS_NTERM

--- a/Source/USE_IFs/MATADD_SSS_NTERM_USE_IFs.f90
+++ b/Source/USE_IFs/MATADD_SSS_NTERM_USE_IFs.f90
@@ -29,7 +29,5 @@
 
       USE OURTIM_Interface
       USE OUTA_HERE_Interface
-      USE ALLOCATE_SPARSE_ALG_Interface
-      USE DEALLOCATE_SPARSE_ALG_Interface
 
       END MODULE MATADD_SSS_NTERM_USE_IFs

--- a/Source/USE_IFs/MATADD_SSS_USE_IFs.f90
+++ b/Source/USE_IFs/MATADD_SSS_USE_IFs.f90
@@ -28,8 +28,5 @@
 ! USE Interface statements for all subroutines called by SUBROUTINE MATADD_SSS
 
       USE OURTIM_Interface
-      USE ALLOCATE_SPARSE_ALG_Interface
-      USE ARRAY_SIZE_ERROR_1_Interface
-      USE DEALLOCATE_SPARSE_ALG_Interface
 
       END MODULE MATADD_SSS_USE_IFs

--- a/Source/UTIL/MATADD_SSS.f90
+++ b/Source/UTIL/MATADD_SSS.f90
@@ -24,7 +24,8 @@
                                                                                                         
 ! End MIT license text.                                                                                      
  
-      SUBROUTINE MATADD_SSS ( NROWS, MAT_A_NAME, NTERM_A, I_A, J_A, A, ALPHA, MAT_B_NAME, NTERM_B, I_B, J_B, B, BETA,  &
+      SUBROUTINE MATADD_SSS ( NROWS, MAT_A_NAME, NTERM_A, I_A, J_A, A, ALPHA,                          &
+                                     MAT_B_NAME, NTERM_B, I_B, J_B, B, BETA,                           &
                                      MAT_C_NAME, NTERM_C, I_C, J_C, C )
  
 !///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -43,13 +44,10 @@
 ! symmetric and have only terms on and above its diagonal in array C. Thus, this subr cannot add 2 matrices where one is stored
 ! symmetric and the other is not. The user is required to ensure that this is the case.
 
-      USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
-      USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, F06
-      USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR
+      USE PENTIUM_II_KIND, ONLY       :  LONG, DOUBLE
+      USE IOUNT1, ONLY                :  WRT_LOG, F04
+      USE SCONTR, ONLY                :  BLNK_SUB_NAM
       USE TIMDAT, ONLY                :  TSEC
-      USE CONSTANTS_1, ONLY           :  ZERO
-      USE DEBUG_PARAMETERS, ONLY      :  DEBUG
-      USE SPARSE_ALG_ARRAYS, ONLY     :  LOGICAL_VEC, REAL_VEC
       USE SUBR_BEGEND_LEVELS, ONLY    :  MATADD_SSS_BEGEND
  
       USE MATADD_SSS_USE_IFs
@@ -60,7 +58,6 @@
       CHARACTER(LEN=*), INTENT(IN)    :: MAT_A_NAME        ! Name of matrix A
       CHARACTER(LEN=*), INTENT(IN)    :: MAT_B_NAME        ! Name of matrix B
       CHARACTER(LEN=*), INTENT(IN)    :: MAT_C_NAME        ! Name of matrix C
-      CHARACTER( 2*BYTE)              :: ALG               ! Which algorithm is used in solving for the terms in a row of C
 
       INTEGER(LONG), INTENT(IN )      :: NROWS             ! Number of rows in input matrices A and B
       INTEGER(LONG), INTENT(IN )      :: NTERM_A           ! Number of nonzero terms in input matrix A
@@ -72,19 +69,6 @@
       INTEGER(LONG), INTENT(IN )      :: J_B(NTERM_B)      ! Col no's for nonzero terms in matrix B
       INTEGER(LONG), INTENT(OUT)      :: I_C(NROWS+1)      ! I_C(I+1) - I_C(I) = no. terms in row I of matrix C
       INTEGER(LONG), INTENT(OUT)      :: J_C(NTERM_C)      ! Col no's for nonzero terms in matrix C
-      INTEGER(LONG)                   :: I,J               ! DO loop indices or counters
-      INTEGER(LONG)                   :: KTERM_C           ! Count of number of terms as they are entered into arrays J_C and C
-      INTEGER(LONG)                   :: MAXIMAX_COL_NUM_A ! Highest col number in matrix A for any row
-      INTEGER(LONG)                   :: MAXIMAX_COL_NUM_B ! Highest col number in matrix B for any row
-      INTEGER(LONG)                   :: MAXIMAX_COL_NUM_C ! Highest col number in matrix C for any row
-      INTEGER(LONG)                   :: MAX_COL_NUM_A     ! Highest col number in matrix A for one row
-      INTEGER(LONG)                   :: MAX_COL_NUM_B     ! Highest col number in matrix B for one row
-      INTEGER(LONG)                   :: MAX_COL_NUM_C     ! Highest col number in matrix C for one row
-      INTEGER(LONG)                   :: MIN_COL_NUM_A     ! Lowest  col number in matrix A for one row
-      INTEGER(LONG)                   :: MIN_COL_NUM_B     ! Lowest  col number in matrix B for one row
-      INTEGER(LONG)                   :: MIN_COL_NUM_C     ! Lowest  col number in matrix C for one row
-      INTEGER(LONG)                   :: NUM_A_ROW_I       ! Num terms in row I of A matrix
-      INTEGER(LONG)                   :: NUM_B_ROW_I       ! Num terms in row I of B matrix
       INTEGER(LONG), PARAMETER        :: SUBR_BEGEND = MATADD_SSS_BEGEND
        
       REAL(DOUBLE) , INTENT(IN )      :: A(NTERM_A)        ! Nonzero terms in matrix A
@@ -110,24 +94,7 @@
       ENDIF
 
 ! **********************************************************************************************************************************
-! Initialize outputs
 
-      DO I=1,NROWS+1
-         I_C(I) = 0
-      ENDDO
-
-      DO I=1,NTERM_C
-         J_C(I) = 0
-           C(I) = ZERO
-      ENDDO
-
-      IF ((DEBUG(81) == 2) .OR. (DEBUG(81) == 3)) CALL MATADD_SSS_DEB ( '1', '   ' )
-
-
-
-
-IF(.TRUE.) THEN
-!----------
       CNT = 0
       I_C(1) = 1
 
@@ -177,151 +144,6 @@ IF(.TRUE.) THEN
       ENDDO
 
 
-      RETURN !victor todo do f04/etc stuff at the end
-
-!----------
-ENDIF
-
-! Determine the highest col number in arrays J_A and J_B
-
-      MAXIMAX_COL_NUM_A = 0
-      DO I=1,NTERM_A
-         IF (J_A(I) > MAXIMAX_COL_NUM_A) THEN
-            MAXIMAX_COL_NUM_A = J_A(I)
-         ENDIF
-      ENDDO 
-
-      MAXIMAX_COL_NUM_B = 0
-      DO I=1,NTERM_B
-         IF (J_B(I) > MAXIMAX_COL_NUM_B) THEN
-            MAXIMAX_COL_NUM_B = J_B(I)
-         ENDIF
-      ENDDO
-
-      MAXIMAX_COL_NUM_C = MAX ( MAXIMAX_COL_NUM_A, MAXIMAX_COL_NUM_B )
-
-! Allocate memory to array LOGICAL_VEC, REAL_VEC (will have as many terms as MAXIMAX_COL_NUM_C and will be initialized to .FALSE.)
-! In the code below, terms in range MIN_COL_NUM_C to MAX_COL_NUM_C will get reset to .TRUE. if there will be a nonzero term
-! in a column of C. The variables MIN_COL_NUM_C and MAX_COL_NUM_C get calculated in the DO loop below for each row of C.)
-
-      CALL ALLOCATE_SPARSE_ALG ( 'LOGICAL_VEC', 1, MAXIMAX_COL_NUM_C, SUBR_NAME )
-      CALL ALLOCATE_SPARSE_ALG (    'REAL_VEC', 1, MAXIMAX_COL_NUM_C, SUBR_NAME )
-
-! Add matrices A and B to get matrix C (in sparse, compressed row storage, format)  
-
-      I_C(1) = 1
-
-      KTERM_C = 0
-      DO I=1,NROWS                                                   ! Cycle over rows of A and B to find terms in matrix C
-
-         NUM_A_ROW_I = I_A(I+1) - I_A(I)                             ! Number of nonzero terms in row I of matrix A
-         NUM_B_ROW_I = I_B(I+1) - I_B(I)                             ! Number of nonzero terms in row I of matrix B
-
-a_nor_b: IF ((NUM_A_ROW_I == 0) .AND. (NUM_B_ROW_I == 0)) THEN       ! This row of A and also of B is null, so C will have no terms
-            ALG = 'NN'
-            MIN_COL_NUM_A = 0
-            MAX_COL_NUM_A = 0
-            MIN_COL_NUM_B = 0
-            MAX_COL_NUM_B = 0
-            MIN_COL_NUM_C = 0
-            MAX_COL_NUM_C = 0
-            I_C(I+1) = I_C(I)
-         ENDIF a_nor_b
-  
-a_no_b:  IF ((NUM_A_ROW_I /= 0) .AND. (NUM_B_ROW_I == 0)) THEN       ! This row of A is not null but row of B is null
-            ALG = 'YN'
-            MIN_COL_NUM_B = 0
-            MAX_COL_NUM_B = 0
-            MIN_COL_NUM_A = J_A(I_A(I))                       
-            MAX_COL_NUM_A = J_A(I_A(I+1)-1)           
-            MIN_COL_NUM_C = MIN_COL_NUM_A
-            MAX_COL_NUM_C = MAX_COL_NUM_A
-            IF (KTERM_C > NTERM_C) CALL ARRAY_SIZE_ERROR_1  ( SUBR_NAME, NTERM_C, MAT_C_NAME ) 
-            I_C(I+1) = I_C(I) + NUM_A_ROW_I
-            DO J=I_A(I),I_A(I+1)-1
-               KTERM_C = KTERM_C + 1
-               J_C(KTERM_C) = J_A(J)
-                 C(KTERM_C) = ALPHA*A(J)
-            ENDDO
-         ENDIF a_no_b
-
-b_no_a:  IF ((NUM_A_ROW_I == 0) .AND. (NUM_B_ROW_I /= 0)) THEN       ! This row of A is null but row of B is not null
-            ALG = 'NY'
-            MIN_COL_NUM_A = 0
-            MAX_COL_NUM_A = 0
-            MIN_COL_NUM_B = J_B(I_B(I))                       
-            MAX_COL_NUM_B = J_B(I_B(I+1)-1)           
-            MIN_COL_NUM_C = MIN_COL_NUM_B
-            MAX_COL_NUM_C = MAX_COL_NUM_B
-            IF (KTERM_C > NTERM_C) CALL ARRAY_SIZE_ERROR_1  ( SUBR_NAME, NTERM_C, MAT_C_NAME ) 
-            I_C(I+1) = I_C(I) + NUM_B_ROW_I
-            DO J=I_B(I),I_B(I+1)-1
-               KTERM_C = KTERM_C + 1
-               J_C(KTERM_C) = J_B(J)
-                 C(KTERM_C) = BETA*B(J)
-            ENDDO
-         ENDIF b_no_a
-
-a_and_b: IF ((NUM_A_ROW_I /= 0) .AND. (NUM_B_ROW_I /= 0)) THEN       ! This row of A and of B is not null.
-
-
-            ALG = 'YY'
-            MIN_COL_NUM_C = MAX (MAXIMAX_COL_NUM_A,MAXIMAX_COL_NUM_B)! For each row of the matrices, the following code finds the
-            MAX_COL_NUM_C = 0                                        ! range of cols (MIN_COL_NUM_C to MAX_COL_NUM_C) over which 
-
-            MIN_COL_NUM_A = J_A(I_A(I))
-            MAX_COL_NUM_A = J_A(I_A(I+1)-1)
-
-            MIN_COL_NUM_B = J_B(I_B(I))
-            MAX_COL_NUM_B = J_B(I_B(I+1)-1)
-
-            MIN_COL_NUM_C = MIN ( MIN_COL_NUM_A, MIN_COL_NUM_B )
-            MAX_COL_NUM_C = MAX ( MAX_COL_NUM_A, MAX_COL_NUM_B )
-
-            DO J=1,MAXIMAX_COL_NUM_C                                 ! Initialize LOGICAL_VEC, REAL_VEC before calc'ing them below
-               LOGICAL_VEC(J) = .FALSE.
-                  REAL_VEC(J) =  ZERO
-            ENDDO
-
-            DO J=I_A(I),I_A(I+1)-1
-               LOGICAL_VEC(J_A(J)) = .TRUE.
-               REAL_VEC(J_A(J)) = REAL_VEC(J_A(J)) + ALPHA*A(J)
-            ENDDO 
-
-            DO J=I_B(I),I_B(I+1)-1
-               LOGICAL_VEC(J_B(J)) = .TRUE.
-               REAL_VEC(J_B(J)) = REAL_VEC(J_B(J)) + BETA*B(J)
-            ENDDO
-
-            I_C(I+1) = I_C(I)                              ! Update I_C
-            DO J=MIN_COL_NUM_C,MAX_COL_NUM_C
-               IF (LOGICAL_VEC(J)) THEN
-                  I_C(I+1) = I_C(I+1) + 1
-               ENDIF
-            ENDDO
-
-            DO J=MIN_COL_NUM_C,MAX_COL_NUM_C
-               IF (LOGICAL_VEC(J)) THEN
-                  KTERM_C = KTERM_C + 1
-                  IF (KTERM_C > NTERM_C) CALL ARRAY_SIZE_ERROR_1  ( SUBR_NAME, NTERM_C, MAT_C_NAME ) 
-                  J_C(KTERM_C) = J
-                    C(KTERM_C) = REAL_VEC(J)
-               ENDIF
-            ENDDO
-
-         ENDIF a_and_b
-
-         IF (ALG /= 'NN') THEN
-            IF ((DEBUG(81) == 2) .OR. (DEBUG(81) == 3)) CALL MATADD_SSS_DEB ( '3', ALG )
-         ENDIF
-
-      ENDDO
-
-      CALL DEALLOCATE_SPARSE_ALG ( 'LOGICAL_VEC' )
-      CALL DEALLOCATE_SPARSE_ALG (    'REAL_VEC' )
-
-      IF ((DEBUG(81) == 2) .OR. (DEBUG(81) == 3)) CALL MATADD_SSS_DEB ( '9', '   ' )
-
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN
          CALL OURTIM
@@ -333,147 +155,5 @@ a_and_b: IF ((NUM_A_ROW_I /= 0) .AND. (NUM_B_ROW_I /= 0)) THEN       ! This row 
 
 ! **********************************************************************************************************************************
 
-! ##################################################################################################################################
-
-      CONTAINS
-
-! ##################################################################################################################################
-
-      SUBROUTINE MATADD_SSS_DEB ( WHICH, ALG )
-
-      CHARACTER(LEN=*), INTENT(IN)    :: ALG               ! Which algorithm is used
-      CHARACTER( 1*BYTE)              :: WHICH             ! Decides what to print out for this call to this subr
-
-      INTEGER(LONG)                   :: DELTA_NTERM_C     ! Number of terms in a row of matrix C
-      INTEGER(LONG)                   :: II,JJ,KK          ! Local DO loop index
-      INTEGER(LONG)                   :: I,J,K             ! Local DO loop index
-
-! **********************************************************************************************************************************
-      IF      (WHICH == '1') THEN
-
-         WRITE(F06,*)
-         WRITE(F06,1011)
-         WRITE(F06,1012)
-         WRITE(F06,1013)
-         WRITE(F06,1014) MAT_A_NAME, MAT_B_NAME, MAT_C_NAME
-         WRITE(F06,1015) NROWS, NTERM_A, NROWS, NTERM_B, NTERM_C
-         WRITE(F06,1016) ALPHA, BETA
-         WRITE(F06,1017)
-         WRITE(F06,*)
-
-      ELSE IF (WHICH == '2') THEN
-
-      ELSE IF (WHICH == '3') THEN
-
-         WRITE(F06,1021)
-         WRITE(F06,1022) I
-         WRITE(F06,1024)
-         WRITE(F06,*)
-
-         DELTA_NTERM_C = I_C(I+1) - I_C(I)
-         DO JJ=1,DELTA_NTERM_C
-            KK = KTERM_C - DELTA_NTERM_C + JJ
-            IF (JJ == 1) THEN
-               WRITE(F06,1031) I, ALG, MIN_COL_NUM_A, MAX_COL_NUM_A, MIN_COL_NUM_B, MAX_COL_NUM_B, MIN_COL_NUM_C, MAX_COL_NUM_C,&
-                               I_C(I), KK, J_C(KK), C(KK)
-            ELSE
-               WRITE(F06,1032) KK, J_C(KK), C(KK)
-            ENDIF
-         ENDDO
-         WRITE(F06,*)
-
-      ELSE IF (WHICH == '4') THEN
-
-      ELSE IF (WHICH == '5') THEN
-
-      ELSE IF (WHICH == '6') THEN
-
-      ELSE IF (WHICH == '7') THEN
-
-      ELSE IF (WHICH == '8') THEN
-
-      ELSE IF (WHICH == '9') THEN
-
-         WRITE(F06,*)
-         WRITE(F06,1091) MAT_C_NAME
-         DO I=1,NROWS+1                                    ! The number of rows in C is the same as that in A
-            WRITE(F06,9192) I,I_C(I)
-         ENDDO
-         WRITE(F06,*)
-         WRITE(F06,1093)
-         DO KK=1,NTERM_C
-            WRITE(F06,1094) KK, J_C(KK), C(KK)
-         ENDDO
-         WRITE(F06,*)
-         WRITE(F06,1095)
-
-      ENDIF
-
-! **********************************************************************************************************************************
- 1011 FORMAT(' __________________________________________________________________________________________________________________',&
-             '_________________'                                                                                               ,//,&
-             ' :::::::::::::::::::::::::::::::::::::::START DEBUG(81) OUTPUT FROM SUBROUTINE MATADD_SSS::::::::::::::::::::::::::',&
-              ':::::::::::::::::',/)
-
- 1012 FORMAT(' SSS SPARSE MATRIX ADD ROUTINE: Add sparse matrices A and B in Compressed Row Storage (CRS) format to obtain CRS',   &
-' sparse matrix C.',/,' ------------------------------')
-
- 1013 FORMAT(' A and B must be stored in the same format with regard to symmetry (if one is stored symmetric, with only terms on' ,&
-' and above the',/,' diagonal, the other must be also stored as symmetric.',/)
-
- 1014 FORMAT(42X,' The name of CRS formatted matrix A is: ',A                                                                   ,/,&
-             42x,' The name of CRS formatted matrix B is: ',A                                                                   ,/,&
-             42x,' The name of CRS formatted matrix C is: ',A,/)
-
- 1015 FORMAT(30X,' Matrix A has ',I8,' rows and             '  ,I12,' nonzero terms'                                            ,/,&
-             30X,' Matrix B has ',I8,' rows and             '  ,I12,' nonzero terms'                                            ,/,&
-             30X,' Matrix C will have same number of rows and ',I12,' nonzero terms*'                                           ,/,&
-             22X,'*(as detrmined by subr MATADD_SSS_NTERM which had to have been run prior to this subr)'/)
-
- 1016 FORMAT(' Add ',1ES14.6,' times matrix A to ',1ES14.6,' times matrix B to obtain matrix C',/)
-
- 1017 FORMAT(                                                                                                                      &
-' Alg YN (below) is for the case where A has terms in the row being processed but B does not'                                   ,/,&
-' Alg NY (below) is for the case where B has terms in the row being processed but A does not'                                   ,/,&
-' Alg YY (below) is for the case where both A and B have nonzero terms in the row being processed'                             ,//,&
-' Output is only given for non null rows of matrix C')
-
- 1021 FORMAT(' ******************************************************************************************************************',&
-              '*****************')
-
- 1022 FORMAT(27X,' W O R K I N G   O N   R O W ',I8,'   O F   O U T P U T   M A T R I X   C',//)
-
- 1024 FORMAT(20X,'Col Num Range For     Col Num Range For     Col Num Range For    Data For Nonzeros For This Row For Matrix C:',/,&
-             20X,'Nonzero Terms In A    Nonzero Terms In B    Nonzero Terms In C   Row Start    Index  Col Nums        Values'  ,/,&
-6X,'Row   Alg     Min Col   Max Col     Min Col   Max Col     Min Col   Max Col      I_C(I)         K    J_C(K)         C(K)'   ,/,&
-            19X,'------------------    ------------------    ------------------    ---------------------------------------------')
-
-
- 1031 FORMAT(1X,I8,4X,A2,  4X,I8,2X,I8,  4X,I8,2X,I8,  4X,I8,2X,I8,2X,  I10,I10,I10,1ES17.6)
-
- 1032 FORMAT(93X,2I10,1ES17.6)
-
- 1091 FORMAT(' ******************************************************************************************************************',&
-              '*****************'                                                                                               ,/,&
-             ' SUMMARY: Compressed Row Storage (CRS) format of matrix C = ',A,':',/,' -------'                                 ,//,&
-             ' 1) Index, L, and array I_C(L) for matrix C, where I_C(L+1) - I_C(L) is the number of nonzero terms in row L of'    ,&
-             ' matrix C.',/,'    (also, I_C(L) is the index, K, in array C(K) where row L begins - up to, but not including, the' ,&
-             ' last entry in I_C(L)).',/)
-
- 9192 FORMAT('    L, I_C(L)       = ',2I12)
-
- 1093 FORMAT(' 2) Index, K, and arrays J_C(K) and C(K). C(K) are the nonzeros in matrix C and J_C(K) is the col number in matrix', &
-             ' C for term C(K).',/)
-
- 1094 FORMAT('    K, J_C(K), C(K) = ',2I12,1ES15.6)
-
- 1095 FORMAT(' ::::::::::::::::::::::::::::::::::::::END DEBUG(81) OUTPUT FROM SUBROUTINE MATADD_SSS:::::::::::::::::::::::::::::',&
-              ':::::::::::::::::'                                                                                               ,/,&
-             ' __________________________________________________________________________________________________________________',&
-             '_________________',/)
-
-! **********************************************************************************************************************************
-
-      END SUBROUTINE MATADD_SSS_DEB
 
       END SUBROUTINE MATADD_SSS

--- a/Source/UTIL/MATADD_SSS.f90
+++ b/Source/UTIL/MATADD_SSS.f90
@@ -93,6 +93,15 @@
       REAL(DOUBLE) , INTENT(IN )      :: BETA              ! Scalar multiplier for matrix B
       REAL(DOUBLE) , INTENT(OUT)      :: C(NTERM_C)        ! Nonzero terms in matrix C
 
+      INTEGER(LONG)                   :: ROW
+      INTEGER(LONG)                   :: P_A
+      INTEGER(LONG)                   :: P_B
+      INTEGER(LONG)                   :: COL_A
+      INTEGER(LONG)                   :: COL_B
+      INTEGER(LONG)                   :: CNT
+      REAL(DOUBLE)                    :: V
+      
+      
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN
          CALL OURTIM
@@ -113,6 +122,65 @@
       ENDDO
 
       IF ((DEBUG(81) == 2) .OR. (DEBUG(81) == 3)) CALL MATADD_SSS_DEB ( '1', '   ' )
+
+
+
+
+IF(.TRUE.) THEN
+!----------
+      CNT = 0
+      I_C(1) = 1
+
+      DO ROW=1,NROWS
+         P_A = I_A(ROW)
+         P_B = I_B(ROW)
+      
+         DO WHILE(P_A < I_A(ROW+1) .OR. P_B < I_B(ROW+1))
+         
+                                                           ! Sentinel when A's row is exhausted
+            IF (P_A < I_A(ROW+1)) then
+               COL_A = J_A(P_A)
+            ELSE
+               COL_A = HUGE(0)
+            ENDIF
+                                                           ! Sentinel when B's row is exhausted
+            IF (P_B < I_B(ROW+1)) then
+               COL_B = J_B(P_B)
+            ELSE
+               COL_B = HUGE(0)
+            ENDIF
+
+ 
+            IF (COL_A < COL_B) THEN                        ! Only A has an entry in this column
+               CNT = CNT + 1
+               C(CNT) = ALPHA * A(P_A)
+               J_C(CNT) = COL_A
+               P_A = P_A + 1
+            ELSE IF (COL_B < COL_A) THEN                   ! Only B has an entry in this column
+               CNT = CNT + 1
+               C(CNT) = BETA * B(P_B)
+               J_C(CNT) = COL_B
+               P_B = P_B + 1
+            ELSE                                           ! Both have an entry — add
+               V = ALPHA * A(P_A) + BETA * B(P_B)
+               CNT = CNT + 1
+               C(CNT) = V
+               J_C(CNT) = COL_A
+               P_A = P_A + 1
+               P_B = P_B + 1
+            ENDIF
+         
+         ENDDO
+      
+         I_C(ROW+1) = CNT + 1
+      
+      ENDDO
+
+
+      RETURN !victor todo do f04/etc stuff at the end
+
+!----------
+ENDIF
 
 ! Determine the highest col number in arrays J_A and J_B
 

--- a/Source/UTIL/MATADD_SSS_NTERM.f90
+++ b/Source/UTIL/MATADD_SSS_NTERM.f90
@@ -84,6 +84,15 @@
       INTEGER(LONG)                   :: NUM_A_ROW_I       ! Num terms in row I of A matrix
       INTEGER(LONG)                   :: NUM_B_ROW_I       ! Num terms in row I of B matrix
       INTEGER(LONG), PARAMETER        :: SUBR_BEGEND = MATADD_SSS_NTERM_BEGEND
+
+
+      INTEGER(LONG)                   :: ROW
+      INTEGER(LONG)                   :: P_A
+      INTEGER(LONG)                   :: P_B
+      INTEGER(LONG)                   :: COL_A
+      INTEGER(LONG)                   :: COL_B
+      INTEGER(LONG)                   :: CNT
+
        
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN
@@ -107,6 +116,65 @@
       NTERM_C = 0
 
       IF ((DEBUG(81) == 1) .OR. (DEBUG(81) == 3)) CALL MATADD_SSS_NTERM_DEB ( '1', '   ' )
+
+
+
+
+
+
+
+
+!----------
+      CNT = 0
+
+      DO ROW=1,NROWS
+         P_A = I_A(ROW)
+         P_B = I_B(ROW)
+      
+         DO WHILE(P_A < I_A(ROW+1) .OR. P_B < I_B(ROW+1))
+         
+                                                           ! Sentinel when A's row is exhausted
+            IF (P_A < I_A(ROW+1)) then
+               COL_A = J_A(P_A)
+            ELSE
+               COL_A = HUGE(0)
+            ENDIF
+                                                           ! Sentinel when B's row is exhausted
+            IF (P_B < I_B(ROW+1)) then
+               COL_B = J_B(P_B)
+            ELSE
+               COL_B = HUGE(0)
+            ENDIF
+
+ 
+            IF (COL_A < COL_B) THEN                        ! Only A has an entry in this column
+               CNT = CNT + 1
+               P_A = P_A + 1
+            ELSE IF (COL_B < COL_A) THEN                   ! Only B has an entry in this column
+               CNT = CNT + 1
+               P_B = P_B + 1
+            ELSE                                           ! Both have an entry
+               CNT = CNT + 1
+               P_A = P_A + 1
+               P_B = P_B + 1
+            ENDIF
+         
+         ENDDO
+            
+      ENDDO
+
+      NTERM_C = CNT
+
+      RETURN !victor todo do f04/etc stuff at the end
+
+!----------
+
+
+
+
+
+
+
 
 ! Determine the highest col number in arrays J_A and J_B
 

--- a/Source/UTIL/MATADD_SSS_NTERM.f90
+++ b/Source/UTIL/MATADD_SSS_NTERM.f90
@@ -39,13 +39,11 @@
 ! symmetric and have only terms on and above its diagonal in array C. Thus, this subr cannot add 2 matrices where one is stored
 ! symmetric and the other is not. The user is required to ensure that this is the case.
 
-      USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
-      USE IOUNT1, ONLY                :  WRT_ERR, WRT_LOG, ERR, F04, F06
-      USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR, WARN_ERR
+      USE PENTIUM_II_KIND, ONLY       :  LONG
+      USE IOUNT1, ONLY                :  WRT_LOG, ERR, F04, F06
+      USE SCONTR, ONLY                :  BLNK_SUB_NAM, FATAL_ERR
       USE TIMDAT, ONLY                :  TSEC
-      USE PARAMS, ONLY                :  SUPWARN
       USE DEBUG_PARAMETERS, ONLY      :  DEBUG
-      USE SPARSE_ALG_ARRAYS, ONLY     :  LOGICAL_VEC
       USE SUBR_BEGEND_LEVELS, ONLY    :  MATADD_SSS_NTERM_BEGEND
  
       USE MATADD_SSS_NTERM_USE_IFs
@@ -60,7 +58,6 @@
 !                                                            or nonsym (all terms)
       CHARACTER(LEN=*), INTENT(IN)    :: SYM_B             ! Flag for whether matrix B is stored sym (terms on and above diag)
 !                                                            or nonsym (all terms)
-      CHARACTER( 2*BYTE)              :: ALG               ! Which algorithm is used in solving for the terms in a row of C
 
       INTEGER(LONG), INTENT(IN )      :: NROWS             ! Number of rows in input matrices A and B
       INTEGER(LONG), INTENT(IN )      :: NTERM_A           ! Number of nonzero terms in input matrix A
@@ -70,19 +67,6 @@
       INTEGER(LONG), INTENT(IN )      :: J_A(NTERM_A)      ! Col no's for nonzero terms in matrix A
       INTEGER(LONG), INTENT(IN )      :: J_B(NTERM_B)      ! Col no's for nonzero terms in matrix B
       INTEGER(LONG), INTENT(OUT)      :: NTERM_C           ! Number of nonzero terms in output matrix C
-      INTEGER(LONG)                   :: DELTA_NTERM_C     ! Number of terms that will go into matrix C for one row
-      INTEGER(LONG)                   :: I,J               ! DO loop indices or counters
-      INTEGER(LONG)                   :: MAXIMAX_COL_NUM_A ! Highest col number in matrix A for any row
-      INTEGER(LONG)                   :: MAXIMAX_COL_NUM_B ! Highest col number in matrix B for any row
-      INTEGER(LONG)                   :: MAXIMAX_COL_NUM_C ! Highest col number in matrix C for any row
-      INTEGER(LONG)                   :: MAX_COL_NUM_A     ! Highest col number in matrix A for one row
-      INTEGER(LONG)                   :: MAX_COL_NUM_B     ! Highest col number in matrix B for one row
-      INTEGER(LONG)                   :: MAX_COL_NUM_C     ! Highest col number in matrix C for one row
-      INTEGER(LONG)                   :: MIN_COL_NUM_A     ! Lowest  col number in matrix A for one row
-      INTEGER(LONG)                   :: MIN_COL_NUM_B     ! Lowest  col number in matrix B for one row
-      INTEGER(LONG)                   :: MIN_COL_NUM_C     ! Lowest  col number in matrix C for one row
-      INTEGER(LONG)                   :: NUM_A_ROW_I       ! Num terms in row I of A matrix
-      INTEGER(LONG)                   :: NUM_B_ROW_I       ! Num terms in row I of B matrix
       INTEGER(LONG), PARAMETER        :: SUBR_BEGEND = MATADD_SSS_NTERM_BEGEND
 
 
@@ -111,20 +95,8 @@
          CALL OUTA_HERE ( 'Y' )
       ENDIF
 
-! Initialize outputs
-
-      NTERM_C = 0
-
-      IF ((DEBUG(81) == 1) .OR. (DEBUG(81) == 3)) CALL MATADD_SSS_NTERM_DEB ( '1', '   ' )
 
 
-
-
-
-
-
-
-!----------
       CNT = 0
 
       DO ROW=1,NROWS
@@ -165,141 +137,6 @@
 
       NTERM_C = CNT
 
-      RETURN !victor todo do f04/etc stuff at the end
-
-!----------
-
-
-
-
-
-
-
-
-! Determine the highest col number in arrays J_A and J_B
-
-      MAXIMAX_COL_NUM_A = 0
-      DO I=1,NTERM_A
-         IF (J_A(I) > MAXIMAX_COL_NUM_A) THEN
-            MAXIMAX_COL_NUM_A = J_A(I)
-         ENDIF
-      ENDDO 
-
-      MAXIMAX_COL_NUM_B = 0
-      DO I=1,NTERM_B
-         IF (J_B(I) > MAXIMAX_COL_NUM_B) THEN
-            MAXIMAX_COL_NUM_B = J_B(I)
-         ENDIF
-      ENDDO
-
-      MAXIMAX_COL_NUM_C = MAX ( MAXIMAX_COL_NUM_A, MAXIMAX_COL_NUM_B )
-
-! Write warning if these MAXIMAX_COL_NUM_A /= MAXIMAX_COL_NUM_B
-!  
-!     IF (MAXIMAX_COL_NUM_A /= MAXIMAX_COL_NUM_B) THEN
-!        WARN_ERR = WARN_ERR + 1
-!        WRITE(ERR,1700) MAT_A_NAME, MAT_B_NAME, SUBR_NAME, MAT_A_NAME, MAXIMAX_COL_NUM_A, MAT_B_NAME, MAXIMAX_COL_NUM_B 
-!        IF (SUPWARN == 'N') THEN
-!           WRITE(F06,1700) MAT_A_NAME, MAT_B_NAME, SUBR_NAME, MAT_A_NAME, MAXIMAX_COL_NUM_A, MAT_B_NAME, MAXIMAX_COL_NUM_B 
-!        ENDIF
-!     ENDIF 
-!  
-      IF ((DEBUG(81) == 1) .OR. (DEBUG(81) == 3)) CALL MATADD_SSS_NTERM_DEB ( '2', '   ' )
-
-! Allocate memory to array LOGICAL_VEC (it will have as many terms as MAXIMAX_COL_NUM_C and will be initialized to .FALSE.)
-! In the code below, terms in range MIN_COL_NUM_C to MAX_COL_NUM_C will get reset to .TRUE. if there will be a nonzero term
-! in a column of C. The variables MIN_COL_NUM_C and MAX_COL_NUM_C get calculated in the DO loop below for each row of C.)
-
-      CALL ALLOCATE_SPARSE_ALG ( 'LOGICAL_VEC', 1, MAXIMAX_COL_NUM_C, SUBR_NAME )
-
-! Count number of terms (NTERM_C) that will go into output matrix C
-
-      DO I=1,NROWS                                                   ! Cycle over rows of A and B to find terms in matrix C
-
-         NUM_A_ROW_I = I_A(I+1) - I_A(I)                             ! Number of nonzero terms in row I of matrix A
-         NUM_B_ROW_I = I_B(I+1) - I_B(I)                             ! Number of nonzero terms in row I of matrix B
-
-a_nor_b: IF ((NUM_A_ROW_I == 0) .AND. (NUM_B_ROW_I == 0)) THEN       ! This row of A and also of B is null, so C will have no terms
-            ALG = 'NN'
-            MIN_COL_NUM_A = 0
-            MAX_COL_NUM_A = 0
-            MIN_COL_NUM_B = 0
-            MAX_COL_NUM_B = 0
-            MIN_COL_NUM_C = 0
-            MAX_COL_NUM_C = 0
-            DELTA_NTERM_C = 0
-         ENDIF a_nor_b
-  
-a_no_b:  IF ((NUM_A_ROW_I /= 0) .AND. (NUM_B_ROW_I == 0)) THEN       ! This row of A is not null but row of B is null
-            ALG = 'YN'
-            MIN_COL_NUM_B = 0
-            MAX_COL_NUM_B = 0
-            MIN_COL_NUM_A = J_A(I_A(I))                       
-            MAX_COL_NUM_A = J_A(I_A(I+1)-1)           
-            MIN_COL_NUM_C = MIN_COL_NUM_A
-            MAX_COL_NUM_C = MAX_COL_NUM_A
-            DELTA_NTERM_C = NUM_A_ROW_I                              ! so DELTA_NTERM_C is only the num of terms in A for this row
-            NTERM_C = NTERM_C + NUM_A_ROW_I
-         ENDIF a_no_b
-
-b_no_a:  IF ((NUM_A_ROW_I == 0) .AND. (NUM_B_ROW_I /= 0)) THEN       ! This row of A is null but row of B is not null
-            ALG = 'NY'
-            MIN_COL_NUM_A = 0
-            MAX_COL_NUM_A = 0
-            MIN_COL_NUM_B = J_B(I_B(I))                       
-            MAX_COL_NUM_B = J_B(I_B(I+1)-1)           
-            MIN_COL_NUM_C = MIN_COL_NUM_B
-            MAX_COL_NUM_C = MAX_COL_NUM_B
-            DELTA_NTERM_C = NUM_B_ROW_I                              ! so DELTA_NTERM_C is only the num of terms in A for this row
-            NTERM_C = NTERM_C + NUM_B_ROW_I
-         ENDIF b_no_a
-
-a_and_b: IF ((NUM_A_ROW_I /= 0) .AND. (NUM_B_ROW_I /= 0)) THEN       ! This row of A and of B is not null.
-
-            ALG = 'YY'
-            MIN_COL_NUM_C = MAX (MAXIMAX_COL_NUM_A,MAXIMAX_COL_NUM_B)! For each row of the matrices, the following code finds the
-            MAX_COL_NUM_C = 0                                        ! range of cols (MIN_COL_NUM_C to MAX_COL_NUM_C) over which 
-
-            MIN_COL_NUM_A = J_A(I_A(I))
-            MAX_COL_NUM_A = J_A(I_A(I+1)-1)
-
-            MIN_COL_NUM_B = J_B(I_B(I))
-            MAX_COL_NUM_B = J_B(I_B(I+1)-1)
-
-            MIN_COL_NUM_C = MIN ( MIN_COL_NUM_A, MIN_COL_NUM_B )
-            MAX_COL_NUM_C = MAX ( MAX_COL_NUM_A, MAX_COL_NUM_B )
-
-            DO J=1,MAXIMAX_COL_NUM_C                                 ! Initialize LOGICAL_VEC before calc'ing it below
-               LOGICAL_VEC(J) = .FALSE.
-            ENDDO
-
-            DO J=I_A(I),I_A(I+1)-1
-               LOGICAL_VEC(J_A(J)) = .TRUE.
-            ENDDO 
-
-            DO J=I_B(I),I_B(I+1)-1
-               LOGICAL_VEC(J_B(J)) = .TRUE.
-            ENDDO
-
-            DELTA_NTERM_C = 0                                        ! LOGICAL_VEC now has T for each col that will have a term in
-            DO J=MIN_COL_NUM_C,MAX_COL_NUM_C                         ! matrix A+B. Count the T's in LOGICAL_VEC. This will be the
-               IF (LOGICAL_VEC(J)) THEN                              ! number of nonzero terms in this row for matrix A+B
-                  DELTA_NTERM_C = DELTA_NTERM_C + 1
-               ENDIF
-            ENDDO
-            NTERM_C = NTERM_C + DELTA_NTERM_C                        ! Update NTERM_C, the total count of nonzero's in A+B  
-
-         ENDIF a_and_b
-
-         IF (ALG /= 'NN') THEN
-            IF ((DEBUG(81) == 1) .OR. (DEBUG(81) == 3)) CALL MATADD_SSS_NTERM_DEB ( '3', ALG )
-         ENDIF
-
-      ENDDO
-
-      CALL DEALLOCATE_SPARSE_ALG ( 'LOGICAL_VEC' )
-
-      IF ((DEBUG(81) == 1) .OR. (DEBUG(81) == 3)) CALL MATADD_SSS_NTERM_DEB ( '9', '   ' )
 
 ! **********************************************************************************************************************************
       IF (WRT_LOG >= SUBR_BEGEND) THEN
@@ -315,116 +152,7 @@ a_and_b: IF ((NUM_A_ROW_I /= 0) .AND. (NUM_B_ROW_I /= 0)) THEN       ! This row 
                     ,/,14X,' INPUT MATRICES ',A,' AND ',A,' MUST BOTH BE STORED IN THE SAME FORMAT (SYM MUST BE BOTH "Y" OR "N").' &
                     ,/,14X,' HOWEVER, MATRIX ',A,' HAS SYM = ',A,' AND MATRIX ',A,' HAS SYM = ',A)
 
- 1700 FORMAT(' *WARNING    : POSSIBLE INCOMPATIBILITY IN ADDING MATRIX ',A,' AND MATRIX ',A,' FOUND IN SUBR ',A                    &
-                    ,/,14X,' THE HIGHEST NUMBER OF A NONZERO COLUMN IN MATRIX ',A,' IS COL NUMBER ',I8,' AND'                      &
-                    ,/,14X,' THE HIGHEST NUMBER OF A NONZERO COLUMN IN MATRIX ',A,' IS COL NUMBER ',I8,'.'                         &
-                    ,/,14X,' THIS IS NOT NECESSARILY AN ERROR, ONLY A NOTE TO THE PROGRAMMER THAT ITS SENSIBILITY BE VERIFIED.'    &
-                    ,/,14X,' THE MOST COMMON CAUSE FOR THIS MESSAGE IS THAT ONE OF THE SPARSE MATRICES HAS NULL COLS ON THE',      &
-                           ' RIGHT SIDE OF THE MATRIX',/)
 
 ! **********************************************************************************************************************************
-
-! ##################################################################################################################################
-
-      CONTAINS
-
-! ##################################################################################################################################
-
-      SUBROUTINE MATADD_SSS_NTERM_DEB ( WHICH, ALG )
-
-      CHARACTER(LEN=*)  , INTENT(IN)  :: ALG               ! Which algorithm is used
-      CHARACTER( 1*BYTE), INTENT(IN)  :: WHICH             ! Decides what to print out for this call to this subr
-
-! **********************************************************************************************************************************
-      IF      (WHICH == '1') THEN
-
-         WRITE(F06,*)
-         WRITE(F06,1011)
-         WRITE(F06,1012)
-         WRITE(F06,1013)
-         WRITE(F06,1014) MAT_A_NAME, MAT_B_NAME, MAT_C_NAME
-         WRITE(F06,1015) NROWS, NTERM_A, NROWS, NTERM_B
-         WRITE(F06,1019)
-         WRITE(F06,*)
-
-      ELSE IF (WHICH == '2') THEN
-
-         WRITE(F06,1021)
-         WRITE(F06,1022)
-         WRITE(F06,1024)
-         WRITE(F06,*)
-      ELSE IF (WHICH == '3') THEN
-
-         WRITE(F06,1031) I, ALG, MIN_COL_NUM_A, MAX_COL_NUM_A, MIN_COL_NUM_B, MAX_COL_NUM_B, MIN_COL_NUM_C, MAX_COL_NUM_C,&
-                         DELTA_NTERM_C, NTERM_C
-                               
-      ELSE IF (WHICH == '4') THEN
-
-      ELSE IF (WHICH == '5') THEN
-
-      ELSE IF (WHICH == '6') THEN
-
-      ELSE IF (WHICH == '7') THEN
-
-      ELSE IF (WHICH == '8') THEN
-
-      ELSE IF (WHICH == '9') THEN
-
-         WRITE(F06,*)
-         WRITE(F06,1091) MAT_C_NAME, NTERM_C
-
-      ENDIF
-
-! **********************************************************************************************************************************
- 1011 FORMAT(' ___________________________________________________________________________________________________________________'&
-            ,'________________'                                                                                                ,//,&
-             ' ::::::::::::::::::::::::::::::::::::START DEBUG(81) OUTPUT FROM SUBROUTINE MATADD_SSS_NTERM:::::::::::::::::::::::',&
-              ':::::::::::::::::',/)
-
- 1012 FORMAT(' SSS SETUP FOR SPARSE MATRIX ADD ROUTINE: Determine memory required for Compressed Row Storage (CRS) formatted',     &
-' matrix C resulting',/,' ---------------------------------------',/,' from the addition of two CRS matrices A and B',/)
-
- 1013 FORMAT(' A and B must be stored in the same format with regard to symmetry (if one is stored symmetric, with only terms on' ,&
-' and above the',/,' diagonal, the other must be also stored as symmetric.',/)
-
- 1014 FORMAT(42X,' The name of CRS formatted matrix A is: ',A                                                                   ,/,&
-             42x,' The name of CRS formatted matrix B is: ',A                                                                   ,/,&
-             42x,' The name of CRS formatted matrix C is: ',A,/)
-
- 1015 FORMAT(30X,' Matrix A has ',I8,' rows and             '  ,I12,' nonzero terms'                                            ,/,&
-             30X,' Matrix B has ',I8,' rows and             '  ,I12,' nonzero terms',/)
-
- 1019 FORMAT(                                                                                                                      &
-' Alg YN (below) is for the case where A has terms in the row being processed but B does not'                                   ,/,&
-' Alg NY (below) is for the case where B has terms in the row being processed but A does not'                                   ,/,&
-' Alg YY (below) is for the case where both A and B have nonzero terms in the row being processed'                             ,//,&
-' Output is only given for non null rows of matrix C')
-
- 1021 FORMAT(' *******************************************************************************************************************'&
-             ,'****************')
-
- 1022 FORMAT(1X,'D E T E R M I N I N G   T H E   N U M B E R   N O N Z E R O S   T E R M S   N E E D E D   F O R   M A T R I X   C'&
-                 ,//)
-
- 1024 FORMAT(20X,'Col Num Range For     Col Num Range For     Col Num Range For    Data For Nonzeros For This Row Of Matrix C:' ,/,&
-             20X,'Nonzero Terms In A    Nonzero Terms In B    Nonzero Terms In C          Number Terms     Accumulative'  ,/,&
-6X,'Row   Alg     Min Col   Max Col     Min Col   Max Col     Min Col   Max Col           In This Row      Number Terms'   ,/,&
-            19X,'------------------    ------------------    ------------------    ---------------------------------------------')
-
-
- 1031 FORMAT(1X,I8,4X,A2,4X,I8,2X,I8,4X,I8,2X,I8,4X,I8,2X,I8,11X,I8,11X,I8,I10)
-
- 1091 FORMAT(' *******************************************************************************************************************'&
-             ,'****************'                                                                                                ,/,&
-             ' SUMMARY: Matrix C = ',A,' will have ',I12,' nonzero terms',/)
-
- 1095 FORMAT(' :::::::::::::::::::::::::::::::::::END DEBUG(81) OUTPUT FROM SUBROUTINE MATADD_SSS_NTERM::::::::::::::::::::::::::',&
-              ':::::::::::::::::'                                                                                               ,/,&
-             ' ___________________________________________________________________________________________________________________'&
-            ,'________________',/)
-
-! **********************************************************************************************************************************
-
-      END SUBROUTINE MATADD_SSS_NTERM_DEB
 
       END SUBROUTINE MATADD_SSS_NTERM


### PR DESCRIPTION
MATADD_SSS and MATADD_SSS_NTERM rewritten with a simpler and much faster algorithm.

Massive speedup for big eigen (103/105) models which add the global stiffness and mass/differential stiffness matrices. Eg: A 262000 element CQUAD4 SOL103 problem took 40 minutes for those two calls before and now takes 0.1 s. (10000 x speedup!)

Should be generally faster for the many other uses of MATADD_SSS too.

Removed DEBUG,81 which was reporting internal details of the old sparse addition algorithm that are no longer present, as well as general comments and stats that don't seem to be any use.