### PR TITLE
METIS/MT fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,10 +89,12 @@ set(METIS_PATCHES_DIR "${PROJECT_SOURCE_DIR}/metis/metis_patches")
 if(NOT DEFINED TPL_ENABLE_METISLIB)
   set(TPL_ENABLE_METISLIB ON CACHE BOOL "Enable METIS for SuperLU")
 endif()
+
 if(TPL_ENABLE_METISLIB)
   if(NOT EXISTS "${GKLIB_DIR}/CMakeLists.txt")
     message(FATAL_ERROR "The GKlib submodule was not downloaded.")
   endif()
+
   if(NOT EXISTS "${METIS_DIR}/CMakeLists.txt")
     message(FATAL_ERROR "The METIS submodule was not downloaded.")
   endif()
@@ -199,6 +201,15 @@ if(USE_SUPERLU_MT)
 
   include_directories("${SUPERLU_MT_DIR}/SRC")
   add_subdirectory(${SUPERLU_MT_DIR})
+
+  if(TPL_ENABLE_METISLIB)
+    if(PLAT STREQUAL "_PTHREAD")
+      add_dependencies(superlu_mt_PTHREAD metis GKlib)
+    elseif(PLAT STREQUAL "_OPENMP")
+      add_dependencies(superlu_mt_OPENMP metis GKlib)
+    endif()
+  endif()
+
   set(SLU_DRIVER "${SUPERLU_MT_DIR}/SRC/c_fortran_pdgssv.c")
 else()
   message(STATUS "Will link against regular SuperLU.")
@@ -212,9 +223,11 @@ else()
 
   include_directories("${SUPERLU_DIR}/SRC")
   add_subdirectory(${SUPERLU_DIR})
+
   if(TPL_ENABLE_METISLIB)
     add_dependencies(superlu metis GKlib)
   endif()
+
   set(SLU_DRIVER "${SUPERLU_DIR}/FORTRAN/c_fortran_dgssv.c")
 endif()
 
@@ -384,6 +397,10 @@ if(USE_SUPERLU_MT)
   endif()
 
   target_compile_definitions(mystran PRIVATE USE_SUPERLU_MT)
+
+  if(TPL_ENABLE_METISLIB)
+    target_compile_definitions(mystran PRIVATE HAVE_METIS)
+  endif()
 else()
   target_link_libraries(mystran superlu f2c)
 endif()

--- a/Source/Modules/PARAMS.f90
+++ b/Source/Modules/PARAMS.f90
@@ -504,9 +504,9 @@
       INTEGER(LONG)            :: F06_COL_START  =     0     ! 1st col in F06 file for output data to begin. If it is not > 2, then
 !                                                              output will be written with each main header centered on one another
 
-      INTEGER(LONG)            :: SPIENV6        =   100     ! Memory growth factor for SuperLU_MT -- corresponds to -sp_ienv(6)
-      INTEGER(LONG)            :: SPIENV7        =   100     ! Memory growth factor for SuperLU_MT -- corresponds to -sp_ienv(7)
-      INTEGER(LONG)            :: SPIENV8        =    50     ! Memory growth factor for SuperLU_MT -- corresponds to -sp_ienv(8)
+      INTEGER(LONG)            :: SPIENV6        =   50     ! Memory growth factor for SuperLU_MT -- corresponds to -sp_ienv(6)
+      INTEGER(LONG)            :: SPIENV7        =   50     ! Memory growth factor for SuperLU_MT -- corresponds to -sp_ienv(7)
+      INTEGER(LONG)            :: SPIENV8        =   30     ! Memory growth factor for SuperLU_MT -- corresponds to -sp_ienv(8)
 
       INTEGER(LONG)            :: SLU_NTHR        =    0     ! Number of threads for SuperLU_MT.
                                                              ! Using 0 will use as many threads as the system has.

--- a/metis/metis_patches/CMakeLists.txt
+++ b/metis/metis_patches/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(METIS C)
+set(CMAKE_C_STANDARD 99)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(SHARED FALSE CACHE BOOL "build a shared library")
@@ -21,27 +22,28 @@ endif(SHARED)
 include(./conf/gkbuild.cmake)
 
 # METIS' custom options
-#option(IDX64 "enable 64 bit ints" OFF)
-#option(REAL64 "enable 64 bit floats (i.e., double)" OFF)
-#if(IDX64)
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DIDXTYPEWIDTH=64")
-#else()
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DIDXTYPEWIDTH=32")
-#endif(IDX64)
-#if(REAL64)
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DREALTYPEWIDTH=64")
-#else()
-#  set(METIS_COPTIONS "${METIS_COPTIONS} -DREALTYPEWIDTH=32")
-#endif(REAL64)
-#
-#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${METIS_COPTIONS}")
+option(IDX64 "enable 64 bit ints" OFF)
+option(REAL64 "enable 64 bit floats (i.e., double)" ON)
 
+if(IDX64)
+  set(_metis_idxwidth 64)
+else()
+  set(_metis_idxwidth 32)
+endif()
 
+if(REAL64)
+  set(_metis_realwidth 64)
+else()
+  set(_metis_realwidth 32)
+endif()
+
+# Generate a metis.h in the build tree that prepends the width defines.
+# Read the source header FIRST so an in-source build cannot corrupt the original.
 set(METIS_GENERATED_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
 file(MAKE_DIRECTORY "${METIS_GENERATED_INCLUDE_DIR}")
-file(WRITE "${METIS_GENERATED_INCLUDE_DIR}/metis.h" "#define IDXTYPEWIDTH 32\n#define REALTYPEWIDTH 32\n")
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/metis.h" METIS_PUBLIC_HEADER)
-file(APPEND "${METIS_GENERATED_INCLUDE_DIR}/metis.h" "${METIS_PUBLIC_HEADER}")
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/metis.h" _metis_public_header)
+file(WRITE "${METIS_GENERATED_INCLUDE_DIR}/metis.h"
+  "#define IDXTYPEWIDTH ${_metis_idxwidth}\n#define REALTYPEWIDTH ${_metis_realwidth}\n${_metis_public_header}")
 
 # Add include directories.
 # i.e., the -I equivalent
@@ -56,6 +58,7 @@ link_directories(${CMAKE_INSTALL_PREFIX}/lib)
 
 # Recursively look for CMakeLists.txt in subdirs.
 add_subdirectory("libmetis")
+
 if(METIS_BUILD_PROGRAMS)
   add_subdirectory("programs")
 endif()

--- a/superlu_mt_patches/CMakeLists.txt
+++ b/superlu_mt_patches/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required(VERSION 3.13)
 
 # Project Version
 project(SuperLU_MT C)
@@ -12,8 +12,8 @@ set(PROJECT_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BugFix})
 set(USE_XSDK_DEFAULTS TRUE)
 
 # The XSDK standard does not allow using internally built BLAS
-if (NOT "${enable_internal_blaslib}" STREQUAL "")
-  if (USE_XSDK_DEFAULTS)
+if(NOT "${enable_internal_blaslib}" STREQUAL "")
+  if(USE_XSDK_DEFAULTS)
     set(enable_blaslib_xSDK OFF)
   else()
     set(enable_blaslib_xSDK ON)
@@ -22,8 +22,8 @@ else()
   set(enable_blaslib_xSDK ${enable_internal_blaslib})
 endif()
 
-if (NOT "${enable_fortran}" STREQUAL "")
-  if (XSDK_ENABLE_Fortran)
+if(NOT "${enable_fortran}" STREQUAL "")
+  if(XSDK_ENABLE_Fortran)
     set(enable_fortran_xSDK ON)
   else()
     set(enable_fortran_xSDK OFF)
@@ -32,42 +32,43 @@ else()
   set(enable_fortran_xSDK ${enable_fortran})
 endif()
 
-set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
+set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
 
 # set up options
-option(enable_internal_blaslib  "Build the CBLAS library" ${enable_blaslib_xSDK})
-option(enable_single    "Enable single precision library" ON)
-option(enable_double    "Enable double precision library" ON)
-option(enable_complex   "Enable complex precision library" ON)
+option(enable_internal_blaslib "Build the CBLAS library" ${enable_blaslib_xSDK})
+option(enable_single "Enable single precision library" ON)
+option(enable_double "Enable double precision library" ON)
+option(enable_complex "Enable complex precision library" ON)
 option(enable_complex16 "Enable complex16 precision library" ON)
 option(enable_matlabmex "Build the Matlab mex library" OFF)
-option(enable_doc       "Add target 'doc' to build Doxygen documentation" OFF)
-option(enable_examples  "Build examples" ON)
-option(enable_fortran   "Build Fortran interface" ${enable_fortran_xSDK})
-option(enable_tests     "Build tests" ON)
-option (BUILD_SHARED_LIBS "shared/static" OFF)
+option(enable_doc "Add target 'doc' to build Doxygen documentation" OFF)
+option(enable_examples "Build examples" ON)
+option(enable_fortran "Build Fortran interface" ${enable_fortran_xSDK})
+option(enable_tests "Build tests" ON)
+option(BUILD_SHARED_LIBS "shared/static" OFF)
 
-include (GNUInstallDirs)
-include (CheckLibraryExists)
+include(GNUInstallDirs)
+include(CheckLibraryExists)
 check_library_exists(m sin "" HAVE_LIB_M)
 
-######################################################################
+# #####################################################################
 #
 # Find packages
 #
-######################################################################
+# #####################################################################
 #
-###find_package (BLAS REQUIRED)
-#-- BLAS
-option(TPL_ENABLE_INTERNAL_BLASLIB  "Build the CBLAS library" ${enable_internal_blaslib})
+# ##find_package (BLAS REQUIRED)
+# -- BLAS
+option(TPL_ENABLE_INTERNAL_BLASLIB "Build the CBLAS library" ${enable_internal_blaslib})
 option(TPL_BLAS_LIBRARIES "List of absolute paths to blas libraries [].")
 
 if(NOT enable_internal_blaslib)
-  if (TPL_BLAS_LIBRARIES)
+  if(TPL_BLAS_LIBRARIES)
     set(BLAS_FOUND TRUE)
   else()
     find_package(BLAS)
-    if (BLAS_FOUND)
+
+    if(BLAS_FOUND)
       set(TPL_BLAS_LIBRARIES "${BLAS_LIBRARIES}" CACHE FILEPATH
         "Set from FindBLAS.cmake BLAS_LIBRARIES." FORCE)
     endif()
@@ -78,49 +79,96 @@ if(BLAS_FOUND)
   message("-- Using TPL_BLAS_LIBRARIES='${TPL_BLAS_LIBRARIES}'")
   set(CMAKE_C_FLAGS "-DUSE_VENDOR_BLAS ${CMAKE_C_FLAGS}")
   set(BLAS_LIB ${TPL_BLAS_LIBRARIES})
+
   # fix up BLAS library name
-  string (REPLACE ";" " " BLAS_LIB_STR "${BLAS_LIB}")
+  string(REPLACE ";" " " BLAS_LIB_STR "${BLAS_LIB}")
   set(BLAS_LIB_EXPORT ${BLAS_LIB_STR})
 else()
   message("-- Did not find or specify BLAS so configure to build internal CBLAS ...")
   add_subdirectory(CBLAS)
   set(BLAS_LIB blas)
-  if (BUILD_SHARED_LIBS)  # export to be referenced by downstream makefile
-      set(BLAS_LIB_EXPORT ${CMAKE_INSTALL_PREFIX}/CBLAS/libblas.so)
+
+  if(BUILD_SHARED_LIBS) # export to be referenced by downstream makefile
+    set(BLAS_LIB_EXPORT ${CMAKE_INSTALL_PREFIX}/CBLAS/libblas.so)
   else()
-      set(BLAS_LIB_EXPORT ${CMAKE_INSTALL_PREFIX}/CBLAS/libblas.a)
+    set(BLAS_LIB_EXPORT ${CMAKE_INSTALL_PREFIX}/CBLAS/libblas.a)
   endif()
 endif()
 
+# -- METIS
+option(TPL_ENABLE_METISLIB "Build the METIS library" OFF)
+option(TPL_METIS_LIBRARIES "List of absolute paths to METIS link libraries [].")
+option(TPL_METIS_INCLUDE_DIRS "List of absolute paths to METIS include directories [].")
 
-set (PLAT "_OPENMP" CACHE STRING "threading flavor _PTHREAD/_OPENMP")
-if (PLAT STREQUAL "_PTHREAD")
-  find_package (Threads REQUIRED)
-elseif (PLAT STREQUAL "_OPENMP")
-  find_package (OpenMP REQUIRED)
-else ()
-  message (SEND_ERROR "invalid PLAT setting")
-endif ()
+# --------------------- METIS ---------------------
+if(TPL_ENABLE_METISLIB) # # want to use metis
+  if(NOT TPL_METIS_LIBRARIES)
+    message(FATAL_ERROR "TPL_METIS_LIBRARIES option should be set for METIS support to be enabled.")
+  endif()
 
-option (LONGINT "use 64-bit integers for indexing sparse matrices (default is 32-bit)" OFF)
+  if(NOT TPL_METIS_INCLUDE_DIRS)
+    message(FATAL_ERROR "TPL_METIS_INCLUDE_DIRS option be set for METIS support to be enabled.")
+  endif()
+
+  foreach(dir ${TPL_METIS_INCLUDE_DIRS})
+    if(NOT MINGW AND NOT EXISTS ${dir})
+      message(FATAL_ERROR "METIS include directory not found: ${dir}")
+    endif()
+
+    set(CMAKE_C_FLAGS "-I${dir} ${CMAKE_C_FLAGS}")
+  endforeach()
+
+  message("-- Enabled support for METIS.")
+  set(METIS_FOUND TRUE)
+
+  set(METIS_LIB ${TPL_METIS_LIBRARIES})
+
+  # fix up METIS library names
+  string(REPLACE ";" " " METIS_LIB_STR "${METIS_LIB}")
+  set(METIS_LIB_EXPORT ${METIS_LIB_STR})
+else()
+  message("-- Will not link with METIS.")
+endif()
+
+if(METIS_FOUND)
+  set(HAVE_METIS TRUE)
+
+  if(TPL_METIS_INCLUDE_DIRS)
+    include_directories(${TPL_METIS_INCLUDE_DIRS})
+  endif()
+endif()
+
+set(PLAT "_OPENMP" CACHE STRING "threading flavor _PTHREAD/_OPENMP")
+
+if(PLAT STREQUAL "_PTHREAD")
+  find_package(Threads REQUIRED)
+elseif(PLAT STREQUAL "_OPENMP")
+  find_package(OpenMP REQUIRED)
+else()
+  message(SEND_ERROR "invalid PLAT setting")
+endif()
+
+option(LONGINT "use 64-bit integers for indexing sparse matrices (default is 32-bit)" OFF)
 
 enable_language(C)
-if (enable_fortran)
+
+if(enable_fortran)
   enable_language(Fortran)
 endif()
+
 set(SUPERLU_MT_VERSION "${PROJECT_VERSION}")
 
-
-set (SUPERLUMT_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/superlu_mt CACHE STRING "include dir")
+set(SUPERLUMT_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/superlu_mt CACHE STRING "include dir")
 
 add_subdirectory(SRC)
+
 # add_subdirectory(EXAMPLE)
 
 # if(enable_tests)
-#   enable_testing()
-#   add_subdirectory(TESTING)
+# enable_testing()
+# add_subdirectory(TESTING)
 # endif()
 
 # if (enable_doc)
-#    add_subdirectory(DOC)
+# add_subdirectory(DOC)
 # endif()

--- a/superlu_mt_patches/SRC/CMakeLists.txt
+++ b/superlu_mt_patches/SRC/CMakeLists.txt
@@ -1,0 +1,37 @@
+
+file(GLOB sources "*.c")
+add_library(superlu_mt${PLAT} ${sources})
+set_target_properties(superlu_mt${PLAT} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+set_property(TARGET superlu_mt${PLAT} PROPERTY C_STANDARD 99)
+
+if(HAVE_LIB_M)
+  target_link_libraries(superlu_mt${PLAT} PRIVATE m)
+endif()
+
+target_link_libraries(superlu_mt${PLAT} PRIVATE ${BLAS_LIB})
+target_compile_definitions(superlu_mt${PLAT} PRIVATE Add_)
+
+if(PLAT STREQUAL "_PTHREAD")
+  target_compile_definitions(superlu_mt${PLAT} PUBLIC __PTHREAD)
+  target_link_libraries(superlu_mt${PLAT} PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+elseif(PLAT STREQUAL "_OPENMP")
+  target_compile_definitions(superlu_mt${PLAT} PUBLIC __OPENMP)
+  target_link_libraries(superlu_mt${PLAT} PRIVATE OpenMP::OpenMP_C)
+endif()
+
+if(LONGINT)
+  target_compile_definitions(superlu_mt${PLAT} PUBLIC _LONGINT)
+endif()
+
+if(HAVE_METIS)
+  target_compile_definitions(superlu_mt${PLAT} PRIVATE HAVE_METIS)
+  target_link_libraries(superlu_mt${PLAT} PRIVATE ${METIS_LIB})
+endif()
+
+target_include_directories(superlu_mt${PLAT} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(superlu_mt${PLAT} INTERFACE $<INSTALL_INTERFACE:include>)
+install(TARGETS superlu_mt${PLAT} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+file(GLOB headers "*.h")
+install(FILES ${headers} DESTINATION ${SUPERLUMT_INSTALL_INCLUDEDIR})

--- a/superlu_mt_patches/SRC/c_fortran_pdgssv.c
+++ b/superlu_mt_patches/SRC/c_fortran_pdgssv.c
@@ -113,7 +113,12 @@ void c_fortran_pdgssv_(int *iopt, int *n, int_t *nnz, int *nrhs, int *nprocs,
      *   permc_spec = 2: minimum degree on structure of A'+A
      *   permc_spec = 3: approximate minimum degree for unsymmetric matrices (COLAMD)
      */
+#if (HAVE_METIS)
+    printf("USING METIS ORDERING\r\n");
+    permc_spec = 6; /* METIS_AT_PLUS_A in MT SuperLU enum */
+#else
     permc_spec = COLAMD;
+#endif
     get_perm_c(permc_spec, &A, perm_c);
 
     /* Initialize the option structure and apply column permutation */
@@ -210,7 +215,6 @@ void c_fortran_pdgssv_(int *iopt, int *n, int_t *nnz, int *nrhs, int *nprocs,
 
 int c_side_slu_nthr = 0;
 
-
 #if (MACH == OPENMP)
 #include <omp.h>
 int sys_nproc() { return omp_get_max_threads(); }
@@ -219,20 +223,21 @@ int sys_nproc() { return omp_get_max_threads(); }
 int sys_nproc() { return 1; }
 #endif
 
-
 /* this can also be called from Fortran, to set the number of threads via
  * the SLU_NTHR PARAM.
  */
-void slu_set_nthr_(int *nthr) {
-  if (*nthr > 0) {
+void slu_set_nthr_(int *nthr)
+{
+  if (*nthr > 0)
+  {
     c_side_slu_nthr = *nthr;
-  } else {
+  }
+  else
+  {
     c_side_slu_nthr = sys_nproc();
   }
   printf("    SuperLU_MT will use %d threads.\n", c_side_slu_nthr);
 }
-
-
 
 /* follows the signature we're used to from the single-threaded driver. */
 void c_fortran_dgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
@@ -242,7 +247,8 @@ void c_fortran_dgssv_(int *iopt, int *n, int_t *nnz, int *nrhs,
                                           pointing to the factored matrices */
                       int_t *info)
 {
-  if (c_side_slu_nthr < 1) {
+  if (c_side_slu_nthr < 1)
+  {
     c_side_slu_nthr = 0;
     slu_set_nthr_(&c_side_slu_nthr);
   }

--- a/superlu_mt_patches/SRC/get_perm_c.c
+++ b/superlu_mt_patches/SRC/get_perm_c.c
@@ -1,0 +1,591 @@
+/*! \file
+Copyright (c) 2003, The Regents of the University of California, through
+Lawrence Berkeley National Laboratory (subject to receipt of any required
+approvals from U.S. Dept. of Energy)
+
+All rights reserved.
+
+The source code is distributed under BSD license, see the file License.txt
+at the top-level directory.
+*/
+/*
+ * -- SuperLU routine (version 3.0) --
+ * Univ. of California Berkeley, Xerox Palo Alto Research Center,
+ * and Lawrence Berkeley National Lab.
+ * November 15, 1997
+ *
+ */
+
+#include "slu_mt_ddefs.h"
+
+/* colamd related */
+#include "colamd.h"
+/** **/
+
+extern int_t genmmd_(int_t *, int_t *, int_t *, int_t *, int_t *, int_t *, int_t *,
+                     int_t *, int_t *, int_t *, int_t *, int_t *);
+
+void get_colamd(
+    const int_t m,   /* number of rows in matrix A. */
+    const int_t n,   /* number of columns in matrix A. */
+    const int_t nnz, /* number of nonzeros in matrix A. */
+    int_t *colptr,   /* column pointer of size n+1 for matrix A. */
+    int_t *rowind,   /* row indices of size nz for matrix A. */
+    int_t *perm_c    /* out - the column permutation vector. */
+)
+{
+  int_t Alen, *A, i, info, *p;
+  double knobs[COLAMD_KNOBS];
+  int_t stats[COLAMD_STATS];
+
+  /*    if ( !(knobs = (double *) SUPERLU_MALLOC(COLAMD_KNOBS * sizeof(double))) )
+  SUPERLU_ABORT("Malloc fails for knobs");*/
+
+  Alen = COLAMD_recommended(nnz, m, n);
+  COLAMD_set_defaults(knobs);
+
+  if (!(A = (int_t *)SUPERLU_MALLOC(Alen * sizeof(int_t))))
+    SUPERLU_ABORT("Malloc fails for A[]");
+  if (!(p = (int_t *)SUPERLU_MALLOC((n + 1) * sizeof(int_t))))
+    SUPERLU_ABORT("Malloc fails for p[]");
+  for (i = 0; i <= n; ++i)
+    p[i] = colptr[i];
+  for (i = 0; i < nnz; ++i)
+    A[i] = rowind[i];
+
+  info = COLAMD_MAIN(m, n, Alen, A, p, knobs, stats);
+
+  if (info == FALSE)
+    SUPERLU_ABORT("COLAMD failed");
+
+  for (i = 0; i < n; ++i)
+    perm_c[p[i]] = i;
+
+  /* SUPERLU_FREE(knobs);*/
+  SUPERLU_FREE(A);
+  SUPERLU_FREE(p);
+}
+
+void get_metis(
+    const int_t n,   /* number of columns in matrix B. */
+    const int_t bnz, /* number of nonzeros in matrix B. */
+    int_t *b_colptr, /* column pointer of size n+1 for matrix B. */
+    int_t *b_rowind, /* row indices of size bnz for matrix B. */
+    int_t *perm_c    /* out - the column permutation vector. */
+)
+{
+#ifdef HAVE_METIS
+/*#define METISOPTIONS 8*/
+#define METISOPTIONS 40
+  int_t metis_options[METISOPTIONS];
+  int_t i, nm;
+  int_t *perm, *iperm;
+
+  extern int_t METIS_NodeND(int_t *, int_t *, int_t *, int_t *, int_t *,
+                            int_t *, int_t *);
+
+  metis_options[0] = 0; /* Use Defaults for now */
+
+  if (!(perm = (int_t *)SUPERLU_MALLOC(2 * n * sizeof(int_t))))
+    SUPERLU_ABORT("SUPERLU_MALLOC fails for perm.");
+  iperm = perm + n;
+  nm = n;
+
+  /* Call metis */
+  METIS_NodeND(&nm, b_colptr, b_rowind, NULL, NULL, perm, iperm);
+
+  /* Copy the permutation vector into SuperLU data structure. */
+  for (i = 0; i < n; ++i)
+    perm_c[i] = iperm[i];
+
+  SUPERLU_FREE(b_colptr);
+  SUPERLU_FREE(b_rowind);
+  SUPERLU_FREE(perm);
+#endif /* HAVE_METIS */
+}
+
+void getata(
+    const int_t m,      /* number of rows in matrix A. */
+    const int_t n,      /* number of columns in matrix A. */
+    const int_t nz,     /* number of nonzeros in matrix A */
+    int_t *colptr,      /* column pointer of size n+1 for matrix A. */
+    int_t *rowind,      /* row indices of size nz for matrix A. */
+    int_t *atanz,       /* out - on exit, returns the actual number of
+                         nonzeros in matrix A'*A. */
+    int_t **ata_colptr, /* out - size n+1 */
+    int_t **ata_rowind  /* out - size *atanz */
+)
+/*
+ * Purpose
+ * =======
+ *
+ * Form the structure of A'*A. A is an m-by-n matrix in column oriented
+ * format represented by (colptr, rowind). The output A'*A is in column
+ * oriented format (symmetrically, also row oriented), represented by
+ * (ata_colptr, ata_rowind).
+ *
+ * This routine is modified from GETATA routine by Tim Davis.
+ * The complexity of this algorithm is: SUM_{i=1,m} r(i)^2,
+ * i.e., the sum of the square of the row counts.
+ *
+ * Questions
+ * =========
+ *     o  Do I need to withhold the *dense* rows?
+ *     o  How do I know the number of nonzeros in A'*A?
+ *
+ */
+{
+  register int_t i, j, k, col, num_nz, ti, trow;
+  int_t *marker, *b_colptr, *b_rowind;
+  int_t *t_colptr, *t_rowind; /* a column oriented form of T = A' */
+
+  if (!(marker = (int_t *)SUPERLU_MALLOC((SUPERLU_MAX(m, n) + 1) * sizeof(int_t))))
+    SUPERLU_ABORT("SUPERLU_MALLOC fails for marker[]");
+  if (!(t_colptr = (int_t *)SUPERLU_MALLOC((m + 1) * sizeof(int_t))))
+    SUPERLU_ABORT("SUPERLU_MALLOC t_colptr[]");
+  if (!(t_rowind = (int_t *)SUPERLU_MALLOC(nz * sizeof(int_t))))
+    SUPERLU_ABORT("SUPERLU_MALLOC fails for t_rowind[]");
+
+  /* Get counts of each column of T, and set up column pointers */
+  for (i = 0; i < m; ++i)
+    marker[i] = 0;
+  for (j = 0; j < n; ++j)
+  {
+    for (i = colptr[j]; i < colptr[j + 1]; ++i)
+      ++marker[rowind[i]];
+  }
+  t_colptr[0] = 0;
+  for (i = 0; i < m; ++i)
+  {
+    t_colptr[i + 1] = t_colptr[i] + marker[i];
+    marker[i] = t_colptr[i];
+  }
+
+  /* Transpose the matrix from A to T */
+  for (j = 0; j < n; ++j)
+    for (i = colptr[j]; i < colptr[j + 1]; ++i)
+    {
+      col = rowind[i];
+      t_rowind[marker[col]] = j;
+      ++marker[col];
+    }
+
+  /* ----------------------------------------------------------------
+     compute B = T * A, where column j of B is:
+
+     Struct (B_*j) =    UNION   ( Struct (T_*k) )
+                      A_kj != 0
+
+     do not include the diagonal entry
+
+     ( Partition A as: A = (A_*1, ..., A_*n)
+       Then B = T * A = (T * A_*1, ..., T * A_*n), where
+       T * A_*j = (T_*1, ..., T_*m) * A_*j.  )
+     ---------------------------------------------------------------- */
+
+  /* Zero the diagonal flag */
+  for (i = 0; i < n; ++i)
+    marker[i] = -1;
+
+  /* First pass determines number of nonzeros in B */
+  num_nz = 0;
+  for (j = 0; j < n; ++j)
+  {
+    /* Flag the diagonal so it's not included in the B matrix */
+    marker[j] = j;
+
+    for (i = colptr[j]; i < colptr[j + 1]; ++i)
+    {
+      /* A_kj is nonzero, add pattern of column T_*k to B_*j */
+      k = rowind[i];
+      for (ti = t_colptr[k]; ti < t_colptr[k + 1]; ++ti)
+      {
+        trow = t_rowind[ti];
+        if (marker[trow] != j)
+        {
+          marker[trow] = j;
+          num_nz++;
+        }
+      }
+    }
+  }
+  *atanz = num_nz;
+
+  /* Allocate storage for A'*A */
+  if (!(*ata_colptr = (int_t *)SUPERLU_MALLOC((n + 1) * sizeof(int_t))))
+    SUPERLU_ABORT("SUPERLU_MALLOC fails for ata_colptr[]");
+  if (*atanz)
+  {
+    if (!(*ata_rowind = (int_t *)SUPERLU_MALLOC(*atanz * sizeof(int_t))))
+      SUPERLU_ABORT("SUPERLU_MALLOC fails for ata_rowind[]");
+  }
+  b_colptr = *ata_colptr; /* aliasing */
+  b_rowind = *ata_rowind;
+
+  /* Zero the diagonal flag */
+  for (i = 0; i < n; ++i)
+    marker[i] = -1;
+
+  /* Compute each column of B, one at a time */
+  num_nz = 0;
+  for (j = 0; j < n; ++j)
+  {
+    b_colptr[j] = num_nz;
+
+    /* Flag the diagonal so it's not included in the B matrix */
+    marker[j] = j;
+
+    for (i = colptr[j]; i < colptr[j + 1]; ++i)
+    {
+      /* A_kj is nonzero, add pattern of column T_*k to B_*j */
+      k = rowind[i];
+      for (ti = t_colptr[k]; ti < t_colptr[k + 1]; ++ti)
+      {
+        trow = t_rowind[ti];
+        if (marker[trow] != j)
+        {
+          marker[trow] = j;
+          b_rowind[num_nz++] = trow;
+        }
+      }
+    }
+  }
+  b_colptr[n] = num_nz;
+
+  SUPERLU_FREE(marker);
+  SUPERLU_FREE(t_colptr);
+  SUPERLU_FREE(t_rowind);
+}
+
+void at_plus_a(
+    const int_t n,    /* number of columns in matrix A. */
+    const int_t nz,   /* number of nonzeros in matrix A */
+    int_t *colptr,    /* column pointer of size n+1 for matrix A. */
+    int_t *rowind,    /* row indices of size nz for matrix A. */
+    int_t *bnz,       /* out - on exit, returns the actual number of
+                             nonzeros in matrix A'*A. */
+    int_t **b_colptr, /* out - size n+1 */
+    int_t **b_rowind  /* out - size *bnz */
+)
+{
+  /*
+   * Purpose
+   * =======
+   *
+   * Form the structure of A'+A. A is an n-by-n matrix in column oriented
+   * format represented by (colptr, rowind). The output A'+A is in column
+   * oriented format (symmetrically, also row oriented), represented by
+   * (b_colptr, b_rowind).
+   *
+   */
+  register int_t i, j, k, col, num_nz;
+  int_t *t_colptr, *t_rowind; /* a column oriented form of T = A' */
+  int_t *marker;
+
+  if (!(marker = (int_t *)SUPERLU_MALLOC(n * sizeof(int_t))))
+    SUPERLU_ABORT("SUPERLU_MALLOC fails for marker[]");
+  if (!(t_colptr = (int_t *)SUPERLU_MALLOC((n + 1) * sizeof(int_t))))
+    SUPERLU_ABORT("SUPERLU_MALLOC fails for t_colptr[]");
+  if (!(t_rowind = (int_t *)SUPERLU_MALLOC(nz * sizeof(int_t))))
+    SUPERLU_ABORT("SUPERLU_MALLOC fails t_rowind[]");
+
+  /* Get counts of each column of T, and set up column pointers */
+  for (i = 0; i < n; ++i)
+    marker[i] = 0;
+  for (j = 0; j < n; ++j)
+  {
+    for (i = colptr[j]; i < colptr[j + 1]; ++i)
+      ++marker[rowind[i]];
+  }
+  t_colptr[0] = 0;
+  for (i = 0; i < n; ++i)
+  {
+    t_colptr[i + 1] = t_colptr[i] + marker[i];
+    marker[i] = t_colptr[i];
+  }
+
+  /* Transpose the matrix from A to T */
+  for (j = 0; j < n; ++j)
+    for (i = colptr[j]; i < colptr[j + 1]; ++i)
+    {
+      col = rowind[i];
+      t_rowind[marker[col]] = j;
+      ++marker[col];
+    }
+
+  /* ----------------------------------------------------------------
+     compute B = A + T, where column j of B is:
+
+     Struct (B_*j) = Struct (A_*k) UNION Struct (T_*k)
+
+     do not include the diagonal entry
+     ---------------------------------------------------------------- */
+
+  /* Zero the diagonal flag */
+  for (i = 0; i < n; ++i)
+    marker[i] = -1;
+
+  /* First pass determines number of nonzeros in B */
+  num_nz = 0;
+  for (j = 0; j < n; ++j)
+  {
+    /* Flag the diagonal so it's not included in the B matrix */
+    marker[j] = j;
+
+    /* Add pattern of column A_*k to B_*j */
+    for (i = colptr[j]; i < colptr[j + 1]; ++i)
+    {
+      k = rowind[i];
+      if (marker[k] != j)
+      {
+        marker[k] = j;
+        ++num_nz;
+      }
+    }
+
+    /* Add pattern of column T_*k to B_*j */
+    for (i = t_colptr[j]; i < t_colptr[j + 1]; ++i)
+    {
+      k = t_rowind[i];
+      if (marker[k] != j)
+      {
+        marker[k] = j;
+        ++num_nz;
+      }
+    }
+  }
+  *bnz = num_nz;
+
+  /* Allocate storage for A+A' */
+  if (!(*b_colptr = (int_t *)SUPERLU_MALLOC((n + 1) * sizeof(int_t))))
+    SUPERLU_ABORT("SUPERLU_MALLOC fails for b_colptr[]");
+  if (*bnz)
+  {
+    if (!(*b_rowind = (int_t *)SUPERLU_MALLOC(*bnz * sizeof(int_t))))
+      SUPERLU_ABORT("SUPERLU_MALLOC fails for b_rowind[]");
+  }
+
+  /* Zero the diagonal flag */
+  for (i = 0; i < n; ++i)
+    marker[i] = -1;
+
+  /* Compute each column of B, one at a time */
+  num_nz = 0;
+  for (j = 0; j < n; ++j)
+  {
+    (*b_colptr)[j] = num_nz;
+
+    /* Flag the diagonal so it's not included in the B matrix */
+    marker[j] = j;
+
+    /* Add pattern of column A_*k to B_*j */
+    for (i = colptr[j]; i < colptr[j + 1]; ++i)
+    {
+      k = rowind[i];
+      if (marker[k] != j)
+      {
+        marker[k] = j;
+        (*b_rowind)[num_nz++] = k;
+      }
+    }
+
+    /* Add pattern of column T_*k to B_*j */
+    for (i = t_colptr[j]; i < t_colptr[j + 1]; ++i)
+    {
+      k = t_rowind[i];
+      if (marker[k] != j)
+      {
+        marker[k] = j;
+        (*b_rowind)[num_nz++] = k;
+      }
+    }
+  }
+  (*b_colptr)[n] = num_nz;
+
+  SUPERLU_FREE(marker);
+  SUPERLU_FREE(t_colptr);
+  SUPERLU_FREE(t_rowind);
+}
+
+void get_perm_c(int_t ispec, SuperMatrix *A, int_t *perm_c)
+/*
+ * Purpose
+ * =======
+ *
+ * GET_PERM_C obtains a permutation matrix Pc, by applying the multiple
+ * minimum degree ordering code by Joseph Liu to matrix A'*A or A+A'.
+ * or using approximate minimum degree column ordering by Davis et. al.
+ * The LU factorization of A*Pc tends to have less fill than the LU
+ * factorization of A.
+ *
+ * Arguments
+ * =========
+ *
+ * ispec   (input) int_t
+ *         Specifies the type of column ordering to reduce fill:
+ *         = 1: minimum degree on the structure of A^T * A
+ *         = 2: minimum degree on the structure of A^T + A
+ *         = 3: approximate minimum degree for unsymmetric matrices
+ *         = 4: METIS ordering on the structure of A^T + A
+ *         If ispec == 0, the natural ordering (i.e., Pc = I) is returned.
+ *
+ * A       (input) SuperMatrix*
+ *         Matrix A in A*X=B, of dimension (A->nrow, A->ncol). The number
+ *         of the linear equations is A->nrow. Currently, the type of A
+ *         can be: Stype = NC; Dtype = _D; Mtype = GE. In the future,
+ *         more general A can be handled.
+ *
+ * perm_c  (output) int_t*
+ *	   Column permutation vector of size A->ncol, which defines the
+ *         permutation matrix Pc; perm_c[i] = j means column i of A is
+ *         in position j in A*Pc.
+ *
+ */
+{
+  NCformat *Astore = A->Store;
+  int_t m, n, bnz, *b_colptr, i;
+  int_t delta, maxint, nofsub, *invp;
+  int_t *b_rowind, *dhead, *qsize, *llist, *marker;
+  double t, SuperLU_timer_();
+
+  m = A->nrow;
+  n = A->ncol;
+
+  t = SuperLU_timer_();
+  switch (ispec)
+  {
+  case 0: /* Natural ordering */
+    for (i = 0; i < n; ++i)
+      perm_c[i] = i;
+#if (PRNTlevel >= 1)
+    printf("Use natural column ordering.\n");
+#endif
+    return;
+  case 1: /* Minimum degree ordering on A'*A */
+    getata(m, n, Astore->nnz, Astore->colptr, Astore->rowind,
+           &bnz, &b_colptr, &b_rowind);
+    printf("Use minimum degree ordering on A'*A.\n");
+    t = SuperLU_timer_() - t;
+#if (PRNTlevel >= 1)
+    printf("Form A'*A time = %8.3f\n", t);
+#endif
+    break;
+  case 2: /* Minimum degree ordering on A'+A */
+    if (m != n)
+      SUPERLU_ABORT("Matrix is not square");
+    at_plus_a(n, Astore->nnz, Astore->colptr, Astore->rowind,
+              &bnz, &b_colptr, &b_rowind);
+    printf("Use minimum degree ordering on A'+A.\n");
+    t = SuperLU_timer_() - t;
+#if (PRNTlevel >= 1)
+    printf("Form A'+A time = %8.3f\n", t);
+#endif
+    break;
+  case 3: /* Approximate minimum degree column ordering. */
+    get_colamd(m, n, Astore->nnz, Astore->colptr, Astore->rowind,
+               perm_c);
+#if (PRNTlevel >= 1)
+    printf(".. Use approximate minimum degree column ordering.\n");
+#endif
+    return;
+  case 4: /* METIS ordering on A'+A */
+    if (m != n)
+      SUPERLU_ABORT("Matrix is not square");
+    at_plus_a(n, Astore->nnz, Astore->colptr, Astore->rowind,
+              &bnz, &b_colptr, &b_rowind);
+    if (bnz)
+    { /* non-empty adjacency structure */
+      get_metis(n, bnz, b_colptr, b_rowind, perm_c);
+    }
+    else
+    { /* e.g., diagonal matrix */
+      for (i = 0; i < n; ++i)
+        perm_c[i] = i;
+      SUPERLU_FREE(b_colptr);
+      /* b_rowind is not allocated in this case */
+    }
+#if (PRNTlevel >= 1)
+    printf(".. Use METIS ordering on A'+A.\n");
+#endif
+    return;
+  case 5: /* PARMETIS -- not available in SuperLU_MT */
+    SUPERLU_ABORT("PARMETIS ordering (ispec=5) is not supported in SuperLU_MT");
+    return;
+  case 6: /* METIS ordering on A'*A (matches METIS_ATA in regular SuperLU) */
+    getata(m, n, Astore->nnz, Astore->colptr, Astore->rowind,
+           &bnz, &b_colptr, &b_rowind);
+    if (bnz)
+    { /* non-empty adjacency structure */
+      get_metis(n, bnz, b_colptr, b_rowind, perm_c);
+    }
+    else
+    { /* e.g., diagonal matrix */
+      for (i = 0; i < n; ++i)
+        perm_c[i] = i;
+      SUPERLU_FREE(b_colptr);
+      /* b_rowind is not allocated in this case */
+    }
+#if (PRNTlevel >= 1)
+    printf(".. Use METIS ordering on A'*A.\n");
+#endif
+    return;
+  default:
+    SUPERLU_ABORT("Invalid ISPEC");
+  }
+
+  if (bnz != 0)
+  {
+    t = SuperLU_timer_();
+
+    /* Initialize and allocate storage for GENMMD. */
+    delta = 0;           /* DELTA is a parameter to allow the choice of nodes
+                      whose degree <= min-degree + DELTA. */
+    maxint = 2147483647; /* 2**31 - 1 */
+    invp = (int_t *)SUPERLU_MALLOC((n + delta) * sizeof(int_t));
+    if (!invp)
+      SUPERLU_ABORT("SUPERLU_MALLOC fails for invp.");
+    dhead = (int_t *)SUPERLU_MALLOC((n + delta) * sizeof(int_t));
+    if (!dhead)
+      SUPERLU_ABORT("SUPERLU_MALLOC fails for dhead.");
+    qsize = (int_t *)SUPERLU_MALLOC((n + delta) * sizeof(int_t));
+    if (!qsize)
+      SUPERLU_ABORT("SUPERLU_MALLOC fails for qsize.");
+    llist = (int_t *)SUPERLU_MALLOC(n * sizeof(int_t));
+    if (!llist)
+      SUPERLU_ABORT("SUPERLU_MALLOC fails for llist.");
+    marker = (int_t *)SUPERLU_MALLOC(n * sizeof(int_t));
+    if (!marker)
+      SUPERLU_ABORT("SUPERLU_MALLOC fails for marker.");
+
+    /* Transform adjacency list into 1-based indexing required by GENMMD.*/
+    for (i = 0; i <= n; ++i)
+      ++b_colptr[i];
+    for (i = 0; i < bnz; ++i)
+      ++b_rowind[i];
+
+    genmmd_(&n, b_colptr, b_rowind, perm_c, invp, &delta, dhead,
+            qsize, llist, marker, &maxint, &nofsub);
+
+    /* Transform perm_c into 0-based indexing. */
+    for (i = 0; i < n; ++i)
+      --perm_c[i];
+
+    SUPERLU_FREE(b_colptr);
+    SUPERLU_FREE(b_rowind);
+    SUPERLU_FREE(invp);
+    SUPERLU_FREE(dhead);
+    SUPERLU_FREE(qsize);
+    SUPERLU_FREE(llist);
+    SUPERLU_FREE(marker);
+
+    t = SuperLU_timer_() - t;
+#if (PRNTlevel >= 1)
+    printf("call GENMMD time = %8.3f\n", t);
+#endif
+  }
+  else
+  { /* Empty adjacency structure */
+    for (i = 0; i < n; ++i)
+      perm_c[i] = i;
+  }
+}

--- a/superlu_mt_patches/SRC/sp_ienv.c
+++ b/superlu_mt_patches/SRC/sp_ienv.c
@@ -12,9 +12,9 @@ at the top-level directory.
 #include "slu_mt_ddefs.h"
 
 /* these can be set from Fortran, allowing MYSTRAN to control them at runtime */
-int_t param_spienv6 = 100;
-int_t param_spienv7 = 100;
-int_t param_spienv8 = 50;
+int_t param_spienv6 = 50;
+int_t param_spienv7 = 50;
+int_t param_spienv8 = 30;
 
 /* this subroutine can be called from Fortran!
  * if the passed growth factor is non-zero, we set it.


### PR DESCRIPTION
This minor PR contains three things:

- Changes to some of the CMake scripts to fix build issues with METIS
- Patches to make METIS work with SuperLU_MT
- Lowered the default values for `SPIENV6`, `SPIENV7`, and `SPIENV8` to match SuperLU_MT defaults, in light of the much-lower memory requirements (and consistency thereof) brought by METIS.