### PR TITLE
Removed Unicode Ü from GPFORCE's INERTIA label and warning

### DIFF
--- a/Source/LK9/L92/GP_FORCE_BALANCE_PROC.f90
+++ b/Source/LK9/L92/GP_FORCE_BALANCE_PROC.f90
@@ -76,9 +76,6 @@
       INTEGER(LONG)                   :: ROW_NUM_START     ! DOF number where TDOF data begins for a grid
       INTEGER(LONG)                   :: TDOF_ROW          ! Row no. in array TDOF to find GDOF DOF number
 
-
-      INTEGER(SHORT), DIMENSION(1)    :: Udd = (/0220/)    ! 0220 is the 4 digit ASCII code for a capital U double-dot
-
       REAL(DOUBLE)                    :: DUM_KE(MELDOF,MELDOF)
       REAL(DOUBLE)                    :: FG1(6)            ! The 6 vals from FG_COL (grid inertia forces) for 1 grid point
       REAL(DOUBLE)                    :: PG1(6)            ! The 6 vals from PG_COL (grid applied loads) for 1 grid point
@@ -769,7 +766,7 @@ i_do1:   DO I=1,NGRID                                      ! (2) Set initial val
 
  9206 FORMAT(1X,   'MPC FORCE              ',6(1ES14.6))
 
- 9207 FORMAT(1X,   'INERTIA FORCE (-Mgg*Üg)',6(1ES14.6))
+ 9207 FORMAT(1X,   'INERTIA FORCE          ',6(1ES14.6))
 
  9208 FORMAT(1X,   'SUBSTRUCTURE I/F FORCE ',6(1ES14.6))
 
@@ -782,7 +779,7 @@ i_do1:   DO I=1,NGRID                                      ! (2) Set initial val
 
  9310 FORMAT(1X,   'TOTALS                :',6(1ES14.6),13X,/,                                                                     &
              1X,   '(may not be zero since there were OMIT''d DOF''s which can mean that the correct inertia forces at the G-set', &
-                   ' are not -Mgg*Üg)',//)
+                   ' are not -Mgg*a*g)',//)
 
  9799 FORMAT(1X,A)
 


### PR DESCRIPTION
Avoids character encoding problems where external tools reading the f06 file as Latin-1 or CP1252 turns `Ü` into two characters, misaligning the values on the rest of the line. Although `Ü` was encoded in UTF-8, external tools can't always assume UTF-8 
because older version of Mystran encoded this character in Latin-1/CP1252 which is invalid UTF-8.

Before:
```
 INERTIA FORCE (-Mgg*Üg)  0.000000E+00  0.000000E+00  3.187583E-14  0.000000E+00  0.000000E+00  0.000000E+00
```

After:
```
 INERTIA FORCE            0.000000E+00  0.000000E+00  3.187583E-14  0.000000E+00  0.000000E+00  0.000000E+00
```
Also, replaces `Ü` with `a` (for acceleration) in the warning that sometimes appears.