### PR TITLE
Bypass uppercase

### DIFF
--- a/Source/LK1/L1A/LOADB.f90
+++ b/Source/LK1/L1A/LOADB.f90
@@ -1174,6 +1174,12 @@ j_do2:            DO J=2,LMPCADDC
          TRIM_LINE = TRIM(LINE)
       ENDDO
 
+      ! Skip capitalizing OUTPUT4 and PARTN, which are executive control commands
+      ! because matrix names like "KRRcb" in their fields are case sensitive.
+      IF ((LINE(1: 7) == 'OUTPUT4') .OR. (LINE(1: 5) == 'PARTN'  )) THEN
+         RETURN
+      ENDIF
+
       DO I = 1,256
           ! remove $
           IF (LINE(I:I) == '$') THEN


### PR DESCRIPTION
Two old benchmarks fail because they need lower case matrix names such as:


```
OUTPUT4   KRR      , KRRcb    , KXX      , LTM      , MCG      //-1/24 $

```
and 
```
PARTN     KRRcb    , KRRCBC   , KRRCBR

```

This PR adds a special case test for them in READ_BDF_LINE()
 to not uppercase the entire line.

A downside is it means OUTPUT4 and PARTN commands are cases sensitive, unlike everything else.

It's also ugly to test every single card being read. It could be restricted to EC commands.

A proper fix might be to rename `KRRcb`, `MRRcb`, `KLR(t)` to upper case and not use this PR.