### PR TITLE
Corner center logic

### DIFF
--- a/Source/LK1/L1A-CC/CHK_CC_CMD_DESCRIBERS.f90
+++ b/Source/LK1/L1A-CC/CHK_CC_CMD_DESCRIBERS.f90
@@ -32,7 +32,7 @@
 
       USE PENTIUM_II_KIND, ONLY        :  BYTE, LONG
       USE IOUNT1, ONLY                 :  WRT_ERR, ERR, F06
-      USE SCONTR, ONLY                 :  BLNK_SUB_NAM, CC_CMD_DESCRIBERS, ECHO, FATAL_ERR, WARN_ERR
+      USE SCONTR, ONLY                 :  BLNK_SUB_NAM, CC_CMD_DESCRIBERS, ECHO, FATAL_ERR, WARN_ERR, NSUB
       USE TIMDAT, ONLY                 :  TSEC
       USE CC_OUTPUT_DESCRIBERS, ONLY   :  STRN_LOC, STRN_OPT, STRE_LOC, STRE_OPT, FORC_LOC
       USE PARAMS, ONLY                 :  SUPWARN
@@ -292,13 +292,14 @@ jdo_1:   DO J=1,NUM_POSS_CCD
 
          DO I=1,NUM_WORDS
 
-            ! TODO: CEN is valid for CENTER (test this)
-            IF      (CC_CMD_DESCRIBERS(I)(1:6) == 'CENTER') THEN
-               STRE_LOC = 'CENTER'
-            ELSE IF (CC_CMD_DESCRIBERS(I)(1:6) == 'CORNER') THEN
-               STRE_LOC = 'CORNER'
-            ELSE IF (CC_CMD_DESCRIBERS(I)(1:5) == 'BILIN' ) THEN
-               STRE_LOC = 'CORNER'
+            IF (NSUB <= 1) THEN
+               IF      (CC_CMD_DESCRIBERS(I)(1:6) == 'CENTER') THEN
+                  STRE_LOC = 'CENTER'
+               ELSE IF (CC_CMD_DESCRIBERS(I)(1:6) == 'CORNER') THEN
+                  STRE_LOC = 'CORNER'
+               ELSE IF (CC_CMD_DESCRIBERS(I)(1:5) == 'BILIN' ) THEN
+                  STRE_LOC = 'CORNER'
+               ENDIF
             ENDIF
 
             ! TODO: MISES is valid for VONMISES (test this...)
@@ -317,13 +318,15 @@ jdo_1:   DO J=1,NUM_POSS_CCD
       IF (WHAT == 'STRN' ) THEN
 
          DO I=1,NUM_WORDS
-            ! TODO: CEN is valid for CENTER (test this)
-            IF      (CC_CMD_DESCRIBERS(I)(1:6) == 'CENTER') THEN
-               STRN_LOC = 'CENTER'
-            ELSE IF (CC_CMD_DESCRIBERS(I)(1:6) == 'CORNER') THEN
-               STRN_LOC = 'CORNER'
-            ELSE IF (CC_CMD_DESCRIBERS(I)(1:5) == 'BILIN' ) THEN
-               STRN_LOC = 'CORNER'
+
+            IF (NSUB <= 1) THEN
+               IF      (CC_CMD_DESCRIBERS(I)(1:6) == 'CENTER') THEN
+                  STRN_LOC = 'CENTER'
+               ELSE IF (CC_CMD_DESCRIBERS(I)(1:6) == 'CORNER') THEN
+                  STRN_LOC = 'CORNER'
+               ELSE IF (CC_CMD_DESCRIBERS(I)(1:5) == 'BILIN' ) THEN
+                  STRN_LOC = 'CORNER'
+               ENDIF
             ENDIF
 
             ! TODO: MISES is valid for VONMISES (test this...)
@@ -343,13 +346,14 @@ jdo_1:   DO J=1,NUM_POSS_CCD
 
          DO I=1,NUM_WORDS
 
-            ! TODO: CEN is valid for CENTER (test this)
-            IF      (CC_CMD_DESCRIBERS(I)(1:6) == 'CENTER') THEN
-               FORC_LOC = 'CENTER'
-            ELSE IF (CC_CMD_DESCRIBERS(I)(1:6) == 'CORNER') THEN
-               FORC_LOC = 'CORNER'
-            ELSE IF (CC_CMD_DESCRIBERS(I)(1:5) == 'BILIN' ) THEN
-               FORC_LOC = 'CORNER'
+            IF (NSUB <= 1) THEN
+               IF      (CC_CMD_DESCRIBERS(I)(1:6) == 'CENTER') THEN
+                  FORC_LOC = 'CENTER'
+               ELSE IF (CC_CMD_DESCRIBERS(I)(1:6) == 'CORNER') THEN
+                  FORC_LOC = 'CORNER'
+               ELSE IF (CC_CMD_DESCRIBERS(I)(1:5) == 'BILIN' ) THEN
+                  FORC_LOC = 'CORNER'
+               ENDIF
             ENDIF
 
          ENDDO

--- a/Source/LK1/L1A/LOADC.f03
+++ b/Source/LK1/L1A/LOADC.f03
@@ -29,13 +29,13 @@
       ! LOADC reads in the CASE CONTROL DECK
       USE PENTIUM_II_KIND, ONLY       :  BYTE, LONG, DOUBLE
       USE IOUNT1, ONLY                :  BUGOUT, ERR, F06, IN1, WRT_ERR
-      USE SCONTR, ONLY                :  BLNK_SUB_NAM, CC_ENTRY_LEN, ENFORCED, FATAL_ERR, WARN_ERR, NSUB, NTSUB, NUM_BUCKLING_SUBS, &
-                                         PROG_NAME, RESTART, SOL_NAME
-      USE TIMDAT, ONLY                :  TSEC
+      USE SCONTR, ONLY                :  CC_ENTRY_LEN, ENFORCED, FATAL_ERR, WARN_ERR, NSUB, NTSUB,                                 &
+                                         NUM_BUCKLING_SUBS, PROG_NAME, RESTART, SOL_NAME, CC_CMD_DESCRIBERS
       USE PARAMS, ONLY                :  SUPINFO, SUPWARN
       USE MODEL_STUF, ONLY            :  CC_EIGR_SID, CC_EIGR_SID_SUB, CC_EIGR_SID_DECK, CC_STATSUB_DECK, CC_STATSUB_SUB,          &
                                          IS_BUCKLING_SUBCASE, IS_MODES_SUBCASE,                                                    &
-                                         MEFFMASS_CALC, MPCSET, MPCSETS, MPFACTOR_CALC, SCNUM, SPCSET, SPCSETS, SUBLOD
+                                         MEFFMASS_CALC, MPCSET, MPCSETS, MPFACTOR_CALC, SCNUM, SPCSET, SPCSETS, SUBLOD,            &
+                                         SC_STRE, SC_STRN, SC_ELFE, SC_ELFN
       USE MODEL_STUF, ONLY            :  EIG_PARAMS,                                                                               &
                                          EIG_COMP, EIG_CRIT, EIG_FRQ1, EIG_FRQ2, EIG_GRID, EIG_LANCZOS_NEV_DELT, EIG_METH,         &
                                          EIG_MSGLVL, EIG_LAP_MAT_TYPE, EIG_MODE, EIG_N1, EIG_N2, EIG_NCVFACL, EIG_NORM, EIG_SID,   &
@@ -46,8 +46,6 @@
       USE TO_UPPER_Interface
       
       IMPLICIT NONE
-
-      CHARACTER(LEN=LEN(BLNK_SUB_NAM)):: SUBR_NAME   = 'LOADC'
 
       CHARACTER( 1*BYTE)              :: DOLLAR_WARN       ! Indicator of whether there was a $ sign in col 1
       CHARACTER(LEN=CC_ENTRY_LEN)     :: CARD              ! Case Control card
@@ -60,7 +58,7 @@
       INTEGER(LONG)                   :: IERR              ! Error indicator. If CHAR not found, IERR set to 1
       INTEGER(LONG)                   :: IOCHK             ! IOSTAT error number when reading a Case Control card from unit IN1
 
-
+      CHARACTER(LEN(CC_CMD_DESCRIBERS)) :: QUAD_LOC
 
 
 ! **********************************************************************************************************************************
@@ -233,6 +231,24 @@ inner:         DO
          ENDIF
 
       ENDDO outer
+
+                                                           ! Assign the same CENTER/CORNER location to all of FORCE,
+                                                           ! STRESS, and STRAIN outputs according to the priority rules.
+                                                           ! Warning. Because NONE is stored as 0 in SC_STRE, etc., this
+                                                           ! treats STRESS(CORNER) = NONE as if STRESS wasn't defined at
+                                                           ! all and defaults to CENTER. That might not be correct.
+      IF       (SC_STRE(1) /= 0) THEN
+         QUAD_LOC = STRE_LOC
+      ELSE IF  (SC_STRN(1) /= 0) THEN
+         QUAD_LOC = STRN_LOC
+      ELSE IF  (SC_ELFE(1) /= 0 .OR. SC_ELFN(1) /= 0) THEN
+         QUAD_LOC = FORC_LOC
+      ELSE
+         QUAD_LOC = 'CENTER'
+      ENDIF
+      STRE_LOC = QUAD_LOC
+      STRN_LOC = QUAD_LOC
+      FORC_LOC = QUAD_LOC
 
       IF (STRN_LOC /= 'CENTER  ') THEN
          WRITE(ERR,1016) STRN_LOC, 'STRAIN'

--- a/Source/LK1/L1A/LOADC.f03
+++ b/Source/LK1/L1A/LOADC.f03
@@ -58,7 +58,7 @@
       INTEGER(LONG)                   :: IERR              ! Error indicator. If CHAR not found, IERR set to 1
       INTEGER(LONG)                   :: IOCHK             ! IOSTAT error number when reading a Case Control card from unit IN1
 
-      CHARACTER(LEN(CC_CMD_DESCRIBERS)) :: QUAD_LOC
+      CHARACTER(LEN(CC_CMD_DESCRIBERS)) :: QUAD4_LOC
 
 
 ! **********************************************************************************************************************************
@@ -234,21 +234,22 @@ inner:         DO
 
                                                            ! Assign the same CENTER/CORNER location to all of FORCE,
                                                            ! STRESS, and STRAIN outputs according to the priority rules.
-                                                           ! Warning. Because NONE is stored as 0 in SC_STRE, etc., this
-                                                           ! treats STRESS(CORNER) = NONE as if STRESS wasn't defined at
-                                                           ! all and defaults to CENTER. That might not be correct.
+                                                           ! Because NONE is stored as 0 in SC_STRE, etc., this treats 
+                                                           ! STRESS(CORNER) = NONE as if STRESS wasn't defined at
+                                                           ! all and defaults to CENTER.
       IF       (SC_STRE(1) /= 0) THEN
-         QUAD_LOC = STRE_LOC
+         QUAD4_LOC = STRE_LOC
       ELSE IF  (SC_STRN(1) /= 0) THEN
-         QUAD_LOC = STRN_LOC
+         QUAD4_LOC = STRN_LOC
       ELSE IF  (SC_ELFE(1) /= 0 .OR. SC_ELFN(1) /= 0) THEN
-         QUAD_LOC = FORC_LOC
+         QUAD4_LOC = FORC_LOC
       ELSE
-         QUAD_LOC = 'CENTER'
+         QUAD4_LOC = 'CENTER'
       ENDIF
-      STRE_LOC = QUAD_LOC
-      STRN_LOC = QUAD_LOC
-      FORC_LOC = QUAD_LOC
+      STRE_LOC = QUAD4_LOC
+      STRN_LOC = QUAD4_LOC
+      FORC_LOC = QUAD4_LOC
+                                                           ! From here on, STRE_LOC = STRN_LOC = FORC_LOC.
 
       IF (STRN_LOC /= 'CENTER  ') THEN
          WRITE(ERR,1016) STRN_LOC, 'STRAIN'
@@ -487,8 +488,7 @@ inner:         DO
 
  1015 FORMAT(' *WARNING    : GRID POINT FORCE BALANCE ONLY ALLOWED IN ',A,' SOLUTION. ABOVE ENTRY IGNORED')
 
- 1016 FORMAT(' *INFORMATION: ALL SUBCASES WILL USE "',A,'" AS THE LOCATION OF ',A,' OUTPUTS FOR PSHELL QUAD4 ELEMENTS'             &
-                    ,/,14X,' SINCE THIS WAS THE FIRST REQUEST, OTHER THAN DEFAULT "CENTER  ", DETECTED')
+ 1016 FORMAT(' *INFORMATION: ALL SUBCASES WILL USE "',A,'" AS THE LOCATION OF ',A,' OUTPUTS FOR PSHELL QUAD4 ELEMENTS')
 
  1028 FORMAT(' *ERROR  1028: THERE MUST BE 2 SUBCASES FOR LINEAR BUCKLING ANALYSES BUT NSUB = ',I8)
 


### PR DESCRIPTION
Changes the decision about which location option (CENTER/blank or CORNER/BILIN) to use for STRESS, STRAIN, and FORCE output requests to match MSC and NX.

Previously, each of STRESS, STRAIN, and FORCE had independent settings. Now they are all made equal.

It decides which location option to use according to the following rules:

1. Only the first subcase is considered. This includes commands put there by the existing behavior of output request commands that are specified before the first subcase being put in the first subcase unless overridden by the same command specified directly in the first subcase.

2. If STRESS is specified, it uses the location option from that, otherwise if STRAIN is specified, it uses the location option from that. If only FORCE is specified, it uses the location option from that, and if none are specified, it defaults to CENTER.

3. A STRESS, STRAIN, or FORCE command with `= NONE` is treated here as not being specified at all. We confirmed that this is the same as NX's behavior, but haven't yet tested it on MSC.